### PR TITLE
fix(rules): pass resource directories to dev mode application root

### DIFF
--- a/quarkifier/src/main/java/com/clementguillot/quarkifier/dev/DevModeLauncher.java
+++ b/quarkifier/src/main/java/com/clementguillot/quarkifier/dev/DevModeLauncher.java
@@ -261,6 +261,10 @@ public final class DevModeLauncher {
             .setSourcePaths(PathList.from(config.sourceDirs()))
             .setClassesPath(classesPath.toAbsolutePath().toString())
             .setResourcePaths(PathList.from(config.resources()))
+            .setResourcesOutputPath(
+                config.resources().isEmpty()
+                    ? null
+                    : config.resources().get(0).toAbsolutePath().toString())
             .setTargetDir(projectRoot.resolve("target").toAbsolutePath().toString())
             .build();
 

--- a/quarkus/private/classpath_utils.bzl
+++ b/quarkus/private/classpath_utils.bzl
@@ -5,6 +5,9 @@ load("@rules_java//java/common:java_info.bzl", "JavaInfo")
 # Maven-layout source root markers used to derive source directories from package paths.
 _SOURCE_MARKERS = ["src/main/java", "src/test/java"]
 
+# Maven-layout resource root markers used to derive resource directories from package paths.
+_RESOURCE_MARKERS = ["src/main/resources"]
+
 def short_path(f):
     """Returns the short_path of a File, for use with args.add_joined(map_each=...)."""
     return f.short_path
@@ -78,3 +81,40 @@ def _add_source_dirs_for_package(pkg_path, seen, source_dirs):
         if candidate not in seen:
             seen[candidate] = True
             source_dirs.append(candidate)
+
+def collect_resource_dir_paths(deps, runtime_classpath = None):
+    """Derives workspace-relative resource directory paths from deps and classpath.
+
+    Examines each dep's package path to derive candidate resource roots using
+    Maven-layout markers (src/main/resources).
+
+    Args:
+        deps: List of targets providing JavaInfo (direct deps).
+        runtime_classpath: Optional depset of transitive runtime jars. If provided,
+            also derives resource dirs from transitive local artifacts.
+    Returns:
+        A deduplicated list of workspace-relative resource directory path strings.
+    """
+    resource_dirs = []
+    seen = {}
+
+    # From direct deps
+    for dep in deps:
+        if JavaInfo in dep:
+            _add_resource_dirs_for_package(dep.label.package, seen, resource_dirs)
+
+    # From transitive runtime classpath (local artifacts only)
+    if runtime_classpath:
+        for jar in runtime_classpath.to_list():
+            if is_local_artifact(jar):
+                _add_resource_dirs_for_package(jar.owner.package, seen, resource_dirs)
+
+    return resource_dirs
+
+def _add_resource_dirs_for_package(pkg_path, seen, resource_dirs):
+    """Adds resource directory candidates for a given package path."""
+    for marker in _RESOURCE_MARKERS:
+        candidate = pkg_path + "/" + marker if pkg_path else marker
+        if candidate not in seen:
+            seen[candidate] = True
+            resource_dirs.append(candidate)

--- a/quarkus/private/dev_launcher.sh.tpl
+++ b/quarkus/private/dev_launcher.sh.tpl
@@ -48,6 +48,13 @@ if [ -f "$SOURCE_DIRS_FILE" ]; then
     SOURCE_DIRS=$(cat "$SOURCE_DIRS_FILE")
 fi
 
+# Read resource directories
+RESOURCE_DIRS_FILE="${RUNFILES_DIR}/%{workspace}/%{resource_dirs_file}"
+RESOURCE_DIRS=""
+if [ -f "$RESOURCE_DIRS_FILE" ]; then
+    RESOURCE_DIRS=$(cat "$RESOURCE_DIRS_FILE")
+fi
+
 # Read Bazel targets and classes output dirs for hot-reload
 BAZEL_TARGETS_FILE="${RUNFILES_DIR}/%{workspace}/%{bazel_targets_file}"
 BAZEL_TARGETS=""
@@ -69,6 +76,24 @@ CLASSES_DIR=""
 WORKSPACE_ROOT="${BUILD_WORKSPACE_DIRECTORY:-$(pwd)}"
 BAZEL_EXEC_ROOT=$(bazel info execution_root 2>/dev/null || printf '%s' "$WORKSPACE_ROOT")
 HOT_RELOAD_ARGS=()
+RESOURCES_ARG=""
+
+# Resolve resource dirs to absolute paths
+if [ -n "$RESOURCE_DIRS" ]; then
+    ABS_RESOURCE_DIRS=""
+    IFS=',' read -ra RD_ENTRIES <<< "$RESOURCE_DIRS"
+    for rd in "${RD_ENTRIES[@]}"; do
+        abs_rd="${WORKSPACE_ROOT}/${rd}"
+        if [ -d "$abs_rd" ]; then
+            if [ -n "$ABS_RESOURCE_DIRS" ]; then ABS_RESOURCE_DIRS="${ABS_RESOURCE_DIRS},"; fi
+            ABS_RESOURCE_DIRS="${ABS_RESOURCE_DIRS}${abs_rd}"
+        fi
+    done
+    if [ -n "$ABS_RESOURCE_DIRS" ]; then
+        RESOURCES_ARG="--resources ${ABS_RESOURCE_DIRS}"
+    fi
+fi
+
 if [ -n "$SOURCE_DIRS" ] && [ -n "$BAZEL_TARGETS" ]; then
     CLASSES_DIR=$(mktemp -d "quarkus_hotreload_classes_XXXXXX")
 
@@ -110,5 +135,6 @@ java \
   --app-name %{app_name} \
   %{app_version_flag} \
   --workspace-dir "$WORKSPACE_ROOT" \
+  ${RESOURCES_ARG} \
   ${HOT_RELOAD_ARGS[@]+"${HOT_RELOAD_ARGS[@]}"} \
   "$@" || exit $?

--- a/quarkus/private/quarkus_dev_impl.bzl
+++ b/quarkus/private/quarkus_dev_impl.bzl
@@ -11,7 +11,7 @@ mutable directory for Quarkus hot-reload.
 
 load("@rules_java//java/common:java_common.bzl", "java_common")
 load("@rules_java//java/common:java_info.bzl", "JavaInfo")
-load("//quarkus/private:classpath_utils.bzl", "collect_runtime_classpath", "collect_source_dir_paths", "is_local_artifact", "short_path")
+load("//quarkus/private:classpath_utils.bzl", "collect_resource_dir_paths", "collect_runtime_classpath", "collect_source_dir_paths", "is_local_artifact", "short_path")
 
 def _collect_bazel_targets(deps):
     """Collects Bazel target labels from deps that have JavaInfo.
@@ -119,6 +119,11 @@ def _quarkus_dev_impl(ctx):
     source_dirs_file = ctx.actions.declare_file(ctx.label.name + "_source_dirs.txt")
     ctx.actions.write(output = source_dirs_file, content = ",".join(source_dirs))
 
+    # Collect resource directories from deps for Quarkus to find them.
+    resource_dirs = collect_resource_dir_paths(ctx.attr.deps, runtime_classpath)
+    resource_dirs_file = ctx.actions.declare_file(ctx.label.name + "_resource_dirs.txt")
+    ctx.actions.write(output = resource_dirs_file, content = ",".join(resource_dirs))
+
     # Collect Bazel target labels for the file watcher to rebuild on changes.
     bazel_targets = _collect_bazel_targets(ctx.attr.deps)
     bazel_targets_file = ctx.actions.declare_file(ctx.label.name + "_bazel_targets.txt")
@@ -143,6 +148,7 @@ def _quarkus_dev_impl(ctx):
             "%{core_deploy_cp_file}": core_deploy_cp_file.short_path,
             "%{deploy_cp_file}": deploy_cp_file.short_path,
             "%{quarkus_version}": ctx.attr.quarkus_version,
+            "%{resource_dirs_file}": resource_dirs_file.short_path,
             "%{source_dirs_file}": source_dirs_file.short_path,
             "%{tool_jar}": tool_jar.short_path,
             "%{workspace}": ctx.workspace_name,
@@ -157,6 +163,7 @@ def _quarkus_dev_impl(ctx):
             deploy_cp_file,
             core_deploy_cp_file,
             source_dirs_file,
+            resource_dirs_file,
             bazel_targets_file,
             classes_output_dirs_file,
         ],


### PR DESCRIPTION
- Closes: #53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dev mode now detects and collects Maven-style resource directories from dependencies and provides them to the development launcher.
  * The dev launcher accepts an optional list of resource paths and passes them to the Quarkus dev tool so resource changes are picked up without manual restart.
  * Resource path resolution uses absolute, existing directories and deduplicates entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/clementguillot/rules_quarkus/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->