### PR TITLE
fix: partition local jars from classpath for correct Jandex indexing

### DIFF
--- a/quarkifier/src/main/java/com/clementguillot/quarkifier/QuarkifierConfig.java
+++ b/quarkifier/src/main/java/com/clementguillot/quarkifier/QuarkifierConfig.java
@@ -34,6 +34,8 @@ import java.util.regex.Pattern;
  *     CLI)
  * @param workspaceDir Bazel workspace root directory for running bazel build (may be {@code null})
  * @param bazelBuildTimeoutSeconds timeout in seconds for bazel build process (default: 60)
+ * @param localAppJars local workspace jars to use as application roots (colon-separated on CLI).
+ *     When empty, the caller handles fallback (e.g. using {@code applicationClasspath.get(0)}).
  */
 public record QuarkifierConfig(
     List<Path> applicationClasspath,
@@ -52,7 +54,8 @@ public record QuarkifierConfig(
     List<String> bazelTargets,
     List<Path> classesOutputDirs,
     Path workspaceDir,
-    long bazelBuildTimeoutSeconds) {
+    long bazelBuildTimeoutSeconds,
+    List<Path> localAppJars) {
 
   private static final String USAGE =
       """
@@ -75,7 +78,8 @@ public record QuarkifierConfig(
               [--bazel-targets <label,label,...>] \\
               [--classes-output-dirs <dir,dir,...>] \\
               [--workspace-dir <path>] \\
-              [--bazel-build-timeout-seconds <seconds>]""";
+              [--bazel-build-timeout-seconds <seconds>] \\
+              [--local-app-jars <jar:jar:...>]""";
 
   /**
    * Parses CLI arguments into an {@link QuarkifierConfig}.
@@ -104,6 +108,7 @@ public record QuarkifierConfig(
     String classesOutputDirs = null;
     String workspaceDir = null;
     String bazelBuildTimeoutSeconds = null;
+    String localAppJars = null;
 
     for (int i = 0; i < args.length; i++) {
       switch (args[i]) {
@@ -140,6 +145,7 @@ public record QuarkifierConfig(
         case "--workspace-dir" -> workspaceDir = requireValue(args, ++i, args[i - 1]);
         case "--bazel-build-timeout-seconds" -> bazelBuildTimeoutSeconds =
             requireValue(args, ++i, args[i - 1]);
+        case "--local-app-jars" -> localAppJars = requireValue(args, ++i, args[i - 1]);
         default -> throw new InvalidArgumentsException("Unknown argument: " + args[i]);
       }
     }
@@ -174,7 +180,8 @@ public record QuarkifierConfig(
         bazelTargets != null ? splitStrings(bazelTargets, ",") : List.of(),
         classesOutputDirs != null ? splitPaths(classesOutputDirs, ",") : List.of(),
         workspaceDir != null ? Path.of(workspaceDir) : null,
-        parsedTimeout);
+        parsedTimeout,
+        localAppJars != null ? splitPaths(localAppJars, ":") : List.of());
   }
 
   /** Serializes this config back to a CLI argument array, suitable for round-trip testing. */
@@ -256,6 +263,11 @@ public record QuarkifierConfig(
     // Always include timeout for round-trip consistency
     list.add("--bazel-build-timeout-seconds");
     list.add(String.valueOf(bazelBuildTimeoutSeconds));
+
+    if (!localAppJars.isEmpty()) {
+      list.add("--local-app-jars");
+      list.add(joinPaths(localAppJars, ":"));
+    }
 
     return list.toArray(String[]::new);
   }

--- a/quarkifier/src/main/java/com/clementguillot/quarkifier/augmentation/AugmentationExecutor.java
+++ b/quarkifier/src/main/java/com/clementguillot/quarkifier/augmentation/AugmentationExecutor.java
@@ -13,6 +13,7 @@ import io.quarkus.bootstrap.app.AugmentResult;
 import io.quarkus.bootstrap.app.CuratedApplication;
 import io.quarkus.bootstrap.app.QuarkusBootstrap;
 import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.paths.PathList;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -48,18 +49,23 @@ public final class AugmentationExecutor {
             "Application classpath is empty; at least one jar is required.");
       }
 
-      Path appJar = appCp.get(0);
-      List<Path> runtimeJars = appCp.subList(1, appCp.size());
+      // Determine local app jars: use --local-app-jars when provided, otherwise
+      // fall back to the first element of the application classpath.
+      List<Path> localAppJars =
+          config.localAppJars().isEmpty() ? List.of(appCp.get(0)) : config.localAppJars();
+
+      // Runtime jars are everything in appCp that is NOT in localAppJars.
+      List<Path> runtimeJars = appCp.stream().filter(jar -> !localAppJars.contains(jar)).toList();
 
       ApplicationModel appModel;
       if (config.mode() == AugmentationMode.TEST) {
         appModel =
             QuarkusAppModelBuilder.buildForTest(
-                appJar, runtimeJars, deployCp, config.appName(), config.appVersion());
+                localAppJars, runtimeJars, deployCp, config.appName(), config.appVersion());
       } else {
         appModel =
             QuarkusAppModelBuilder.build(
-                appJar, runtimeJars, deployCp, config.appName(), config.appVersion());
+                localAppJars, runtimeJars, deployCp, config.appName(), config.appVersion());
       }
 
       // DEV mode: delegate to DevModeLauncher which starts IsolatedDevModeMain
@@ -82,7 +88,7 @@ public final class AugmentationExecutor {
         return;
       }
 
-      runAugmentation(config, appJar, appModel, outputDir);
+      runAugmentation(config, localAppJars, appModel, outputDir);
 
       // NATIVE mode: run augmentation with native-sources-only properties,
       // then validate output via NativeSourcesAssembler instead of FastJarAssembler.
@@ -104,7 +110,7 @@ public final class AugmentationExecutor {
 
   /** Runs the Quarkus bootstrap and augmentation for production/test modes. */
   private static void runAugmentation(
-      QuarkifierConfig config, Path appJar, ApplicationModel appModel, Path outputDir)
+      QuarkifierConfig config, List<Path> localAppJars, ApplicationModel appModel, Path outputDir)
       throws Exception {
 
     Properties buildProps =
@@ -115,7 +121,7 @@ public final class AugmentationExecutor {
     QuarkusBootstrap bootstrap =
         QuarkusBootstrap.builder()
             .setExistingModel(appModel)
-            .setApplicationRoot(appJar)
+            .setApplicationRoot(PathList.from(localAppJars))
             .setTargetDirectory(outputDir)
             .setBaseName(
                 config.mode() == AugmentationMode.NATIVE && config.appName() != null

--- a/quarkifier/src/main/java/com/clementguillot/quarkifier/augmentation/AugmentationExecutor.java
+++ b/quarkifier/src/main/java/com/clementguillot/quarkifier/augmentation/AugmentationExecutor.java
@@ -49,13 +49,9 @@ public final class AugmentationExecutor {
             "Application classpath is empty; at least one jar is required.");
       }
 
-      // Determine local app jars: use --local-app-jars when provided, otherwise
-      // fall back to the first element of the application classpath.
-      List<Path> localAppJars =
-          config.localAppJars().isEmpty() ? List.of(appCp.get(0)) : config.localAppJars();
-
-      // Runtime jars are everything in appCp that is NOT in localAppJars.
-      List<Path> runtimeJars = appCp.stream().filter(jar -> !localAppJars.contains(jar)).toList();
+      ClasspathPartition partition = partitionClasspath(config);
+      List<Path> localAppJars = partition.localAppJars();
+      List<Path> runtimeJars = partition.runtimeJars();
 
       ApplicationModel appModel;
       if (config.mode() == AugmentationMode.TEST) {
@@ -183,4 +179,35 @@ public final class AugmentationExecutor {
       case DEV -> QuarkusBootstrap.Mode.DEV;
     };
   }
+
+  /**
+   * Partitions the application classpath into local app jars (used as application roots for Jandex
+   * indexing) and runtime jars (external Maven dependencies).
+   *
+   * <p>Package-private for testability.
+   */
+  static ClasspathPartition partitionClasspath(QuarkifierConfig config)
+      throws AugmentationException {
+    List<Path> appCp = config.applicationClasspath();
+
+    // Determine local app jars: use --local-app-jars when provided, otherwise
+    // fall back to the first element of the application classpath.
+    List<Path> localAppJars =
+        config.localAppJars().isEmpty() ? List.of(appCp.get(0)) : config.localAppJars();
+
+    List<Path> unknownLocalAppJars =
+        localAppJars.stream().filter(jar -> !appCp.contains(jar)).toList();
+    if (!unknownLocalAppJars.isEmpty()) {
+      throw new AugmentationException(
+          "--local-app-jars must be a subset of the application classpath: " + unknownLocalAppJars);
+    }
+
+    // Runtime jars are everything in appCp that is NOT in localAppJars.
+    List<Path> runtimeJars = appCp.stream().filter(jar -> !localAppJars.contains(jar)).toList();
+
+    return new ClasspathPartition(localAppJars, runtimeJars);
+  }
+
+  /** Result of partitioning the application classpath. Package-private for testability. */
+  record ClasspathPartition(List<Path> localAppJars, List<Path> runtimeJars) {}
 }

--- a/quarkifier/src/main/java/com/clementguillot/quarkifier/model/QuarkusAppModelBuilder.java
+++ b/quarkifier/src/main/java/com/clementguillot/quarkifier/model/QuarkusAppModelBuilder.java
@@ -48,8 +48,10 @@ public final class QuarkusAppModelBuilder {
    * Builds an {@link ApplicationModel} from classpath jars, detecting Quarkus extensions and
    * setting the appropriate dependency flags.
    *
-   * @param appJar the application's own jar (first entry on the application classpath)
-   * @param runtimeJars remaining runtime dependency jars
+   * @param localAppJars local workspace jars — the first element becomes the app artifact, and
+   *     remaining jars are added as runtime dependencies (they are also indexed via the application
+   *     root {@code PathCollection} mechanism in the caller)
+   * @param runtimeJars remaining runtime dependency jars (external Maven jars)
    * @param deployClasspath deployment-only jars
    * @param appName optional application name override
    * @param appVersion optional application version override
@@ -57,7 +59,7 @@ public final class QuarkusAppModelBuilder {
    * @throws IOException if jar scanning fails
    */
   public static ApplicationModel build(
-      Path appJar,
+      List<Path> localAppJars,
       List<Path> runtimeJars,
       List<Path> deployClasspath,
       String appName,
@@ -86,7 +88,16 @@ public final class QuarkusAppModelBuilder {
                 .toList());
     extensionJars.addAll(deployExtensionJars);
 
+    Path appJar = localAppJars.get(0);
     setAppArtifact(modelBuilder, appJar, appName, appVersion);
+
+    // Add additional local app jars (index 1+) as runtime dependencies so they
+    // appear in the model. They are also indexed via the application root
+    // PathCollection mechanism in AugmentationExecutor.
+    if (localAppJars.size() > 1) {
+      addLocalAppJarDependencies(modelBuilder, localAppJars.subList(1, localAppJars.size()));
+    }
+
     Set<ArtifactKey> addedKeys = addRuntimeDependencies(modelBuilder, runtimeJars, extensionJars);
     addDeploymentDependencies(modelBuilder, deployClasspath, addedKeys, extensionJars);
     markParentFirstArtifacts(modelBuilder);
@@ -156,15 +167,17 @@ public final class QuarkusAppModelBuilder {
    * Builds an {@link ApplicationModel} for test mode, including a {@link WorkspaceModule} with test
    * sources so that {@code AppMakerHelper} can locate test classes.
    *
-   * @param appJar the application's own jar (first entry on the application classpath)
-   * @param runtimeJars remaining runtime dependency jars
+   * @param localAppJars local workspace jars — the first element becomes the app artifact, and
+   *     remaining jars are added as runtime dependencies (they are also indexed via the application
+   *     root {@code PathCollection} mechanism in the caller)
+   * @param runtimeJars remaining runtime dependency jars (external Maven jars)
    * @param deployClasspath deployment-only jars
    * @param appName optional application name override
    * @param appVersion optional application version override
    * @return a fully configured ApplicationModel with workspace module for test mode
    */
   public static ApplicationModel buildForTest(
-      Path appJar,
+      List<Path> localAppJars,
       List<Path> runtimeJars,
       List<Path> deployClasspath,
       String appName,
@@ -198,7 +211,16 @@ public final class QuarkusAppModelBuilder {
                 .toList());
     extensionJars.addAll(deployExtensionJars);
 
+    Path appJar = localAppJars.get(0);
     setAppArtifactForTest(modelBuilder, appJar, appName, appVersion);
+
+    // Add additional local app jars (index 1+) as runtime dependencies so they
+    // appear in the model. They are also indexed via the application root
+    // PathCollection mechanism in AugmentationExecutor.
+    if (localAppJars.size() > 1) {
+      addLocalAppJarDependencies(modelBuilder, localAppJars.subList(1, localAppJars.size()));
+    }
+
     Set<ArtifactKey> addedKeys = addRuntimeDependencies(modelBuilder, runtimeJars, extensionJars);
     addDeploymentDependencies(modelBuilder, deployClasspath, addedKeys, extensionJars);
     markParentFirstArtifacts(modelBuilder);
@@ -265,6 +287,29 @@ public final class QuarkusAppModelBuilder {
             .setWorkspaceModule(module)
             .setRuntimeCp()
             .setDeploymentCp());
+  }
+
+  /**
+   * Adds additional local app jars (beyond the first one which is the app artifact) as runtime
+   * dependencies in the model. These jars are local workspace modules that need to be on the
+   * runtime and deployment classpaths so the augmentation classloader can find them. They are also
+   * indexed via the application root {@code PathCollection} mechanism.
+   */
+  private static void addLocalAppJarDependencies(
+      ApplicationModelBuilder modelBuilder, List<Path> additionalLocalJars) {
+    for (Path jar : additionalLocalJars) {
+      var coords = MavenCoordinateParser.parse(jar);
+      modelBuilder.addDependency(
+          ResolvedDependencyBuilder.newInstance()
+              .setGroupId(coords.groupId())
+              .setArtifactId(coords.artifactId())
+              .setVersion(coords.version())
+              .setType(JAR_TYPE)
+              .setResolvedPath(jar)
+              .setRuntimeCp()
+              .setDeploymentCp()
+              .setDirect(true));
+    }
   }
 
   /** Adds runtime jars as dependencies, marking extension jars appropriately. */

--- a/quarkifier/src/test/java/com/clementguillot/quarkifier/PreservationPropertyTest.java
+++ b/quarkifier/src/test/java/com/clementguillot/quarkifier/PreservationPropertyTest.java
@@ -1,0 +1,271 @@
+package com.clementguillot.quarkifier;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.clementguillot.quarkifier.model.QuarkusAppModelBuilder;
+import io.quarkus.bootstrap.model.ApplicationModel;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Preservation property tests for the bugfix.
+ *
+ * <p>These tests capture BASELINE behavior that must be preserved after the fix. They should PASS
+ * on the current unfixed code.
+ *
+ * <p><b>Validates: Requirements 3.1, 3.2, 3.3, 3.4, 3.5</b>
+ */
+class PreservationPropertyTest {
+
+  private static final Random RNG = new Random(42);
+  private static final int TRIES = 100;
+
+  @TempDir Path tempDir;
+
+  // ---- Property: External Maven jars are NEVER the appJar in QuarkusAppModelBuilder ----
+
+  /**
+   * Property: External Maven jars are passed as runtime dependencies (runtimeJars), not as appJar.
+   *
+   * <p>For any classpath configuration where the first jar is a local app jar and the remaining
+   * jars are external Maven dependencies, the model's app artifact should always be the first jar
+   * (the local one), and external jars should appear only as dependencies.
+   *
+   * <p><b>Validates: Requirements 3.1</b>
+   */
+  @ParameterizedTest
+  @MethodSource("classpathConfigurations")
+  void externalMavenJarsAreRuntimeDependenciesNotAppArtifact(ClasspathConfig config)
+      throws IOException {
+    // Create the app jar (local workspace jar)
+    Path appJar = createJar(config.appGroupId(), config.appArtifactId(), config.appVersion());
+
+    // Create external Maven jars (runtime dependencies)
+    List<Path> runtimeJars = new ArrayList<>();
+    for (MavenJarInfo mavenJar : config.mavenJars()) {
+      runtimeJars.add(createJar(mavenJar.groupId(), mavenJar.artifactId(), mavenJar.version()));
+    }
+
+    // Build the model — localAppJars contains the app jar, runtimeJars are external deps
+    ApplicationModel model =
+        QuarkusAppModelBuilder.build(
+            List.of(appJar), runtimeJars, List.of(), config.appName(), "1.0");
+
+    // Assert: app artifact is the local jar, not any Maven jar
+    assertEquals(
+        config.appName() != null ? config.appName() : config.appArtifactId(),
+        model.getAppArtifact().getArtifactId(),
+        "App artifact should be the local jar");
+
+    // Assert: all Maven jars appear as dependencies, not as the app artifact
+    for (MavenJarInfo mavenJar : config.mavenJars()) {
+      boolean foundAsDep =
+          model.getDependencies().stream()
+              .anyMatch(d -> mavenJar.artifactId().equals(d.getArtifactId()));
+      assertTrue(
+          foundAsDep, "Maven jar " + mavenJar.artifactId() + " should be a runtime dependency");
+    }
+  }
+
+  /**
+   * Property: Single-module project with one local jar correctly uses that jar as app artifact.
+   *
+   * <p>When there is exactly one local jar (the app jar) and zero or more Maven dependencies, the
+   * app artifact in the model is always that single local jar.
+   *
+   * <p><b>Validates: Requirements 3.2</b>
+   */
+  @ParameterizedTest
+  @MethodSource("singleModuleConfigurations")
+  void singleLocalJarIsAlwaysAppArtifact(SingleModuleConfig config) throws IOException {
+    Path appJar = createJar(config.groupId(), config.artifactId(), config.version());
+
+    List<Path> runtimeJars = new ArrayList<>();
+    for (MavenJarInfo mavenJar : config.mavenDeps()) {
+      runtimeJars.add(createJar(mavenJar.groupId(), mavenJar.artifactId(), mavenJar.version()));
+    }
+
+    ApplicationModel model =
+        QuarkusAppModelBuilder.build(
+            List.of(appJar), runtimeJars, List.of(), config.appName(), config.version());
+
+    // The app artifact must be the single local jar
+    String expectedArtifactId = config.appName() != null ? config.appName() : config.artifactId();
+    assertEquals(
+        expectedArtifactId,
+        model.getAppArtifact().getArtifactId(),
+        "Single local jar must be the app artifact");
+    assertEquals(
+        config.groupId(),
+        model.getAppArtifact().getGroupId(),
+        "App artifact groupId must match the local jar");
+    assertEquals(
+        config.version(),
+        model.getAppArtifact().getVersion(),
+        "App artifact version must match the local jar");
+  }
+
+  /**
+   * Property: QuarkifierConfig.parse() correctly parses --application-classpath and
+   * --deployment-classpath flags for all valid configurations.
+   *
+   * <p><b>Validates: Requirements 3.4, 3.5</b>
+   */
+  @ParameterizedTest
+  @MethodSource("com.clementguillot.quarkifier.TestDataGenerator#randomValidConfigs")
+  void parseCorrectlyParsesClasspathFlags(QuarkifierConfig original)
+      throws QuarkifierConfig.InvalidArgumentsException {
+    String[] args = original.toArgs();
+    QuarkifierConfig parsed = QuarkifierConfig.parse(args);
+
+    // Application classpath must round-trip exactly
+    assertEquals(
+        original.applicationClasspath(),
+        parsed.applicationClasspath(),
+        "applicationClasspath must round-trip");
+
+    // Deployment classpath must round-trip exactly
+    assertEquals(
+        original.deploymentClasspath(),
+        parsed.deploymentClasspath(),
+        "deploymentClasspath must round-trip");
+
+    // Core deployment classpath must round-trip exactly
+    assertEquals(
+        original.coreDeploymentClasspath(),
+        parsed.coreDeploymentClasspath(),
+        "coreDeploymentClasspath must round-trip");
+  }
+
+  /**
+   * Property: QuarkifierConfig.parse() round-trips correctly via toArgs() for ALL fields.
+   *
+   * <p><b>Validates: Requirements 3.3, 3.4, 3.5</b>
+   */
+  @ParameterizedTest
+  @MethodSource("com.clementguillot.quarkifier.TestDataGenerator#randomValidConfigs")
+  void configRoundTripPreservesAllFields(QuarkifierConfig original)
+      throws QuarkifierConfig.InvalidArgumentsException {
+    String[] args = original.toArgs();
+    QuarkifierConfig parsed = QuarkifierConfig.parse(args);
+
+    assertEquals(original.applicationClasspath(), parsed.applicationClasspath());
+    assertEquals(original.deploymentClasspath(), parsed.deploymentClasspath());
+    assertEquals(original.coreDeploymentClasspath(), parsed.coreDeploymentClasspath());
+    assertEquals(original.outputDir(), parsed.outputDir());
+    assertEquals(original.resources(), parsed.resources());
+    assertEquals(original.mode(), parsed.mode());
+    assertEquals(original.expectedQuarkusVersion(), parsed.expectedQuarkusVersion());
+    assertEquals(original.appName(), parsed.appName());
+    assertEquals(original.appVersion(), parsed.appVersion());
+    assertEquals(original.mainClass(), parsed.mainClass());
+    assertEquals(original.nativeBuilderImage(), parsed.nativeBuilderImage());
+    assertEquals(original.sourceDirs(), parsed.sourceDirs());
+    assertEquals(original.classesDir(), parsed.classesDir());
+    assertEquals(original.bazelTargets(), parsed.bazelTargets());
+    assertEquals(original.classesOutputDirs(), parsed.classesOutputDirs());
+    assertEquals(original.workspaceDir(), parsed.workspaceDir());
+    assertEquals(original.bazelBuildTimeoutSeconds(), parsed.bazelBuildTimeoutSeconds());
+    assertEquals(original.localAppJars(), parsed.localAppJars());
+  }
+
+  // ---- Data generators ----
+
+  static Stream<ClasspathConfig> classpathConfigurations() {
+    return IntStream.range(0, TRIES).mapToObj(i -> randomClasspathConfig());
+  }
+
+  static Stream<SingleModuleConfig> singleModuleConfigurations() {
+    return IntStream.range(0, TRIES).mapToObj(i -> randomSingleModuleConfig());
+  }
+
+  private static ClasspathConfig randomClasspathConfig() {
+    String appGroupId = "com." + randomAlpha(3, 8);
+    String appArtifactId = randomAlpha(4, 12);
+    String appVersion = randomVersion();
+    String appName = RNG.nextDouble() < 0.3 ? null : randomAlpha(3, 10);
+
+    int mavenJarCount = 1 + RNG.nextInt(5);
+    List<MavenJarInfo> mavenJars = new ArrayList<>();
+    for (int i = 0; i < mavenJarCount; i++) {
+      mavenJars.add(
+          new MavenJarInfo(
+              "io." + randomAlpha(3, 8),
+              randomAlpha(5, 15) + "-" + randomAlpha(3, 6),
+              randomVersion()));
+    }
+
+    return new ClasspathConfig(appGroupId, appArtifactId, appVersion, appName, mavenJars);
+  }
+
+  private static SingleModuleConfig randomSingleModuleConfig() {
+    String groupId = "com." + randomAlpha(3, 8);
+    String artifactId = randomAlpha(4, 12);
+    String version = randomVersion();
+    String appName = RNG.nextDouble() < 0.3 ? null : randomAlpha(3, 10);
+
+    int mavenDepCount = RNG.nextInt(6); // 0 to 5 Maven deps
+    List<MavenJarInfo> mavenDeps = new ArrayList<>();
+    for (int i = 0; i < mavenDepCount; i++) {
+      mavenDeps.add(
+          new MavenJarInfo("org." + randomAlpha(3, 8), randomAlpha(5, 15), randomVersion()));
+    }
+
+    return new SingleModuleConfig(groupId, artifactId, version, appName, mavenDeps);
+  }
+
+  // ---- Helpers ----
+
+  private Path createJar(String groupId, String artifactId, String version) throws IOException {
+    Path dir =
+        tempDir.resolve("jars/" + groupId.replace('.', '/') + "/" + artifactId + "/" + version);
+    Files.createDirectories(dir);
+    Path jar = dir.resolve(artifactId + "-" + version + ".jar");
+    try (var jos = new JarOutputStream(new FileOutputStream(jar.toFile()))) {
+      jos.putNextEntry(new JarEntry("META-INF/"));
+      jos.closeEntry();
+    }
+    return jar;
+  }
+
+  private static String randomAlpha(int minLen, int maxLen) {
+    int len = minLen + RNG.nextInt(maxLen - minLen + 1);
+    var sb = new StringBuilder(len);
+    for (int i = 0; i < len; i++) sb.append((char) ('a' + RNG.nextInt(26)));
+    return sb.toString();
+  }
+
+  private static String randomVersion() {
+    return RNG.nextInt(10) + "." + RNG.nextInt(30) + "." + RNG.nextInt(20);
+  }
+
+  // ---- Data records ----
+
+  record MavenJarInfo(String groupId, String artifactId, String version) {}
+
+  record ClasspathConfig(
+      String appGroupId,
+      String appArtifactId,
+      String appVersion,
+      String appName,
+      List<MavenJarInfo> mavenJars) {}
+
+  record SingleModuleConfig(
+      String groupId,
+      String artifactId,
+      String version,
+      String appName,
+      List<MavenJarInfo> mavenDeps) {}
+}

--- a/quarkifier/src/test/java/com/clementguillot/quarkifier/TestDataGenerator.java
+++ b/quarkifier/src/test/java/com/clementguillot/quarkifier/TestDataGenerator.java
@@ -36,7 +36,8 @@ final class TestDataGenerator {
         randomBazelTargetList(0, 3),
         randomPathList(0, 4),
         RNG.nextDouble() < 0.3 ? null : randomSafePath(),
-        randomTimeout());
+        randomTimeout(),
+        randomPathList(0, 3));
   }
 
   private static long randomTimeout() {

--- a/quarkifier/src/test/java/com/clementguillot/quarkifier/augmentation/AugmentationExecutorBugConditionTest.java
+++ b/quarkifier/src/test/java/com/clementguillot/quarkifier/augmentation/AugmentationExecutorBugConditionTest.java
@@ -2,6 +2,7 @@ package com.clementguillot.quarkifier.augmentation;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.clementguillot.quarkifier.AugmentationException;
 import com.clementguillot.quarkifier.AugmentationMode;
 import com.clementguillot.quarkifier.QuarkifierConfig;
 import java.nio.file.Path;
@@ -9,167 +10,129 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 /**
- * Bug condition exploration test for the application root selection logic in {@link
- * AugmentationExecutor}.
+ * Tests for the classpath partitioning logic in {@link AugmentationExecutor}.
  *
- * <p>These tests verify the FIXED behavior: when {@code --local-app-jars} is provided, all local
- * workspace jars are used as application roots. The fix ensures that the executor uses {@code
- * config.localAppJars()} (when non-empty) instead of just {@code appCp.get(0)}.
+ * <p>These tests drive assertions through the production {@code partitionClasspath()} helper to
+ * ensure that the actual executor logic correctly separates local workspace jars from external
+ * Maven jars.
  *
- * <p><b>Validates: Requirements 1.1, 1.2, 1.3, 1.4</b>
+ * <p><b>Validates: Requirements 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.3, 2.4</b>
  */
 class AugmentationExecutorBugConditionTest {
 
   /**
-   * Fixed scenario: Maven jar is first in the classpath, but --local-app-jars identifies the local
-   * jars.
-   *
-   * <p>Given applicationClasspath = [maven.jar, local1.jar, local2.jar] with --local-app-jars =
-   * [local1.jar, local2.jar], the executor determines application roots from config.localAppJars().
-   * The result is that ALL local jars are used as application roots.
-   *
-   * <p>This reproduces the AugmentationExecutor.execute() logic for determining localAppJars.
+   * When --local-app-jars identifies local jars and a Maven jar is first in the classpath, the
+   * production partitioning logic places all local jars in {@code localAppJars} and the Maven jar
+   * in {@code runtimeJars}.
    */
   @Test
-  void allLocalJarsShouldBeApplicationRoots_mavenJarFirst() {
-    // Simulate: applicationClasspath = [maven.jar, local1.jar, local2.jar]
-    // With the fix, the Bazel rule now provides --local-app-jars to identify local jars.
+  void partitionClasspath_localAppJarsProvided_mavenJarFirst() throws AugmentationException {
     Path mavenJar =
         Path.of("external/maven/io/quarkus/quarkus-rest/3.33.1/quarkus-rest-3.33.1.jar");
     Path local1Jar = Path.of("bazel-out/bin/services/api/libapi.jar");
     Path local2Jar = Path.of("bazel-out/bin/services/domain/libdomain.jar");
 
-    List<Path> applicationClasspath = List.of(mavenJar, local1Jar, local2Jar);
-    List<Path> localAppJars = List.of(local1Jar, local2Jar);
-
-    // Create a config simulating the FIXED invocation — with --local-app-jars flag
     QuarkifierConfig config =
-        new QuarkifierConfig(
-            applicationClasspath,
-            List.of(Path.of("deploy.jar")),
-            List.of(),
-            Path.of("/tmp/output"),
-            List.of(),
-            AugmentationMode.NORMAL,
-            null,
-            "test-app",
-            "1.0",
-            null,
-            null,
-            List.of(),
-            null,
-            List.of(),
-            List.of(),
-            null,
-            60,
-            localAppJars);
+        configWith(List.of(mavenJar, local1Jar, local2Jar), List.of(local1Jar, local2Jar));
 
-    // Reproduce the executor's logic for determining application roots:
-    // List<Path> localAppJars = config.localAppJars().isEmpty()
-    //     ? List.of(appCp.get(0))
-    //     : config.localAppJars();
-    List<Path> appCp = config.applicationClasspath();
-    List<Path> actualApplicationRoots =
-        config.localAppJars().isEmpty() ? List.of(appCp.get(0)) : config.localAppJars();
+    AugmentationExecutor.ClasspathPartition partition =
+        AugmentationExecutor.partitionClasspath(config);
 
-    // Verify ALL local jars are in the application roots
-    List<Path> expectedLocalJars = List.of(local1Jar, local2Jar);
-
-    for (Path expectedLocalJar : expectedLocalJars) {
-      assertTrue(
-          actualApplicationRoots.contains(expectedLocalJar),
-          "Local jar "
-              + expectedLocalJar
-              + " should be in application roots, "
-              + "but actual roots are: "
-              + actualApplicationRoots);
-    }
-
-    // Verify that the Maven jar is NOT in the application roots
-    assertFalse(
-        actualApplicationRoots.contains(mavenJar),
-        "Maven jar "
-            + mavenJar
-            + " should NOT be in application roots, "
-            + "but actual roots are: "
-            + actualApplicationRoots);
-
-    // Verify the runtime jars (everything not in localAppJars) exclude local jars
-    List<Path> runtimeJars =
-        appCp.stream().filter(jar -> !actualApplicationRoots.contains(jar)).toList();
-    assertTrue(runtimeJars.contains(mavenJar), "Maven jar should be in runtime jars");
-    assertFalse(runtimeJars.contains(local1Jar), "Local jar should NOT be in runtime jars");
-    assertFalse(runtimeJars.contains(local2Jar), "Local jar should NOT be in runtime jars");
+    assertEquals(
+        List.of(local1Jar, local2Jar),
+        partition.localAppJars(),
+        "All local jars should be application roots");
+    assertEquals(
+        List.of(mavenJar), partition.runtimeJars(), "Maven jar should be a runtime dependency");
   }
 
   /**
-   * Fixed scenario: Multi-module project with local jars first.
-   *
-   * <p>Given applicationClasspath = [local1.jar, local2.jar, maven.jar] with --local-app-jars =
-   * [local1.jar, local2.jar], the executor uses ALL local jars as application roots. Previously,
-   * only local1.jar (appCp.get(0)) would be used.
+   * Multi-module project with local jars first in the classpath. The production partitioning must
+   * include ALL local jars as application roots, not just the first one.
    */
   @Test
-  void allLocalJarsShouldBeApplicationRoots_multiModuleLocalFirst() {
-    // Simulate: applicationClasspath = [local1.jar, local2.jar, maven.jar]
+  void partitionClasspath_localAppJarsProvided_multiModuleLocalFirst()
+      throws AugmentationException {
     Path local1Jar = Path.of("bazel-out/bin/services/api/libapi.jar");
     Path local2Jar = Path.of("bazel-out/bin/services/domain/libdomain.jar");
     Path mavenJar =
         Path.of("external/maven/io/quarkus/quarkus-rest/3.33.1/quarkus-rest-3.33.1.jar");
 
-    List<Path> applicationClasspath = List.of(local1Jar, local2Jar, mavenJar);
-    List<Path> localAppJars = List.of(local1Jar, local2Jar);
+    QuarkifierConfig config =
+        configWith(List.of(local1Jar, local2Jar, mavenJar), List.of(local1Jar, local2Jar));
+
+    AugmentationExecutor.ClasspathPartition partition =
+        AugmentationExecutor.partitionClasspath(config);
+
+    assertEquals(2, partition.localAppJars().size(), "Both local jars should be application roots");
+    assertTrue(partition.localAppJars().contains(local1Jar));
+    assertTrue(partition.localAppJars().contains(local2Jar));
+    assertFalse(
+        partition.localAppJars().contains(mavenJar), "Maven jar must not be an application root");
+    assertEquals(List.of(mavenJar), partition.runtimeJars());
+  }
+
+  /**
+   * When --local-app-jars is empty (backward compat), the production partitioning falls back to
+   * appCp.get(0) as the sole application root.
+   */
+  @Test
+  void partitionClasspath_noLocalAppJars_fallsBackToFirstEntry() throws AugmentationException {
+    Path firstJar = Path.of("bazel-out/bin/lib/liblib.jar");
+    Path secondJar =
+        Path.of("external/maven/io/quarkus/quarkus-core/3.33.1/quarkus-core-3.33.1.jar");
 
     QuarkifierConfig config =
-        new QuarkifierConfig(
-            applicationClasspath,
-            List.of(Path.of("deploy.jar")),
-            List.of(),
-            Path.of("/tmp/output"),
-            List.of(),
-            AugmentationMode.NORMAL,
-            null,
-            "test-app",
-            "1.0",
-            null,
-            null,
-            List.of(),
-            null,
-            List.of(),
-            List.of(),
-            null,
-            60,
-            localAppJars);
+        configWith(List.of(firstJar, secondJar), List.of()); // no --local-app-jars
 
-    // Reproduce the executor's logic for determining application roots
-    List<Path> appCp = config.applicationClasspath();
-    List<Path> actualApplicationRoots =
-        config.localAppJars().isEmpty() ? List.of(appCp.get(0)) : config.localAppJars();
+    AugmentationExecutor.ClasspathPartition partition =
+        AugmentationExecutor.partitionClasspath(config);
 
-    // Expected: BOTH local1 and local2 should be application roots
-    List<Path> expectedLocalJars = List.of(local1Jar, local2Jar);
+    assertEquals(List.of(firstJar), partition.localAppJars(), "Should fall back to appCp.get(0)");
+    assertEquals(List.of(secondJar), partition.runtimeJars());
+  }
 
-    assertEquals(
-        expectedLocalJars.size(),
-        actualApplicationRoots.size(),
-        "All local jars should be application roots. "
-            + "Expected "
-            + expectedLocalJars.size()
-            + " roots "
-            + expectedLocalJars
-            + " but got "
-            + actualApplicationRoots.size()
-            + " root(s): "
-            + actualApplicationRoots);
+  /**
+   * When --local-app-jars contains a jar not in the application classpath, the production code
+   * should throw.
+   */
+  @Test
+  void partitionClasspath_localAppJarNotInClasspath_throws() {
+    Path appJar = Path.of("bazel-out/bin/lib/liblib.jar");
+    Path unknownJar = Path.of("bazel-out/bin/other/libother.jar");
 
-    for (Path expectedLocalJar : expectedLocalJars) {
-      assertTrue(
-          actualApplicationRoots.contains(expectedLocalJar),
-          "Local jar "
-              + expectedLocalJar
-              + " should be in application roots, "
-              + "but actual roots are: "
-              + actualApplicationRoots);
-    }
+    QuarkifierConfig config =
+        configWith(
+            List.of(appJar), List.of(unknownJar)); // unknownJar is not in applicationClasspath
+
+    AugmentationException ex =
+        assertThrows(
+            AugmentationException.class, () -> AugmentationExecutor.partitionClasspath(config));
+    assertTrue(ex.getMessage().contains("must be a subset"));
+  }
+
+  // ---- Helper ----
+
+  private static QuarkifierConfig configWith(
+      List<Path> applicationClasspath, List<Path> localAppJars) {
+    return new QuarkifierConfig(
+        applicationClasspath,
+        List.of(Path.of("deploy.jar")),
+        List.of(),
+        Path.of("/tmp/output"),
+        List.of(),
+        AugmentationMode.NORMAL,
+        null,
+        "test-app",
+        "1.0",
+        null,
+        null,
+        List.of(),
+        null,
+        List.of(),
+        List.of(),
+        null,
+        60,
+        localAppJars);
   }
 }

--- a/quarkifier/src/test/java/com/clementguillot/quarkifier/augmentation/AugmentationExecutorBugConditionTest.java
+++ b/quarkifier/src/test/java/com/clementguillot/quarkifier/augmentation/AugmentationExecutorBugConditionTest.java
@@ -1,0 +1,175 @@
+package com.clementguillot.quarkifier.augmentation;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.clementguillot.quarkifier.AugmentationMode;
+import com.clementguillot.quarkifier.QuarkifierConfig;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Bug condition exploration test for the application root selection logic in {@link
+ * AugmentationExecutor}.
+ *
+ * <p>These tests verify the FIXED behavior: when {@code --local-app-jars} is provided, all local
+ * workspace jars are used as application roots. The fix ensures that the executor uses {@code
+ * config.localAppJars()} (when non-empty) instead of just {@code appCp.get(0)}.
+ *
+ * <p><b>Validates: Requirements 1.1, 1.2, 1.3, 1.4</b>
+ */
+class AugmentationExecutorBugConditionTest {
+
+  /**
+   * Fixed scenario: Maven jar is first in the classpath, but --local-app-jars identifies the local
+   * jars.
+   *
+   * <p>Given applicationClasspath = [maven.jar, local1.jar, local2.jar] with --local-app-jars =
+   * [local1.jar, local2.jar], the executor determines application roots from config.localAppJars().
+   * The result is that ALL local jars are used as application roots.
+   *
+   * <p>This reproduces the AugmentationExecutor.execute() logic for determining localAppJars.
+   */
+  @Test
+  void allLocalJarsShouldBeApplicationRoots_mavenJarFirst() {
+    // Simulate: applicationClasspath = [maven.jar, local1.jar, local2.jar]
+    // With the fix, the Bazel rule now provides --local-app-jars to identify local jars.
+    Path mavenJar =
+        Path.of("external/maven/io/quarkus/quarkus-rest/3.33.1/quarkus-rest-3.33.1.jar");
+    Path local1Jar = Path.of("bazel-out/bin/services/api/libapi.jar");
+    Path local2Jar = Path.of("bazel-out/bin/services/domain/libdomain.jar");
+
+    List<Path> applicationClasspath = List.of(mavenJar, local1Jar, local2Jar);
+    List<Path> localAppJars = List.of(local1Jar, local2Jar);
+
+    // Create a config simulating the FIXED invocation — with --local-app-jars flag
+    QuarkifierConfig config =
+        new QuarkifierConfig(
+            applicationClasspath,
+            List.of(Path.of("deploy.jar")),
+            List.of(),
+            Path.of("/tmp/output"),
+            List.of(),
+            AugmentationMode.NORMAL,
+            null,
+            "test-app",
+            "1.0",
+            null,
+            null,
+            List.of(),
+            null,
+            List.of(),
+            List.of(),
+            null,
+            60,
+            localAppJars);
+
+    // Reproduce the executor's logic for determining application roots:
+    // List<Path> localAppJars = config.localAppJars().isEmpty()
+    //     ? List.of(appCp.get(0))
+    //     : config.localAppJars();
+    List<Path> appCp = config.applicationClasspath();
+    List<Path> actualApplicationRoots =
+        config.localAppJars().isEmpty() ? List.of(appCp.get(0)) : config.localAppJars();
+
+    // Verify ALL local jars are in the application roots
+    List<Path> expectedLocalJars = List.of(local1Jar, local2Jar);
+
+    for (Path expectedLocalJar : expectedLocalJars) {
+      assertTrue(
+          actualApplicationRoots.contains(expectedLocalJar),
+          "Local jar "
+              + expectedLocalJar
+              + " should be in application roots, "
+              + "but actual roots are: "
+              + actualApplicationRoots);
+    }
+
+    // Verify that the Maven jar is NOT in the application roots
+    assertFalse(
+        actualApplicationRoots.contains(mavenJar),
+        "Maven jar "
+            + mavenJar
+            + " should NOT be in application roots, "
+            + "but actual roots are: "
+            + actualApplicationRoots);
+
+    // Verify the runtime jars (everything not in localAppJars) exclude local jars
+    List<Path> runtimeJars =
+        appCp.stream().filter(jar -> !actualApplicationRoots.contains(jar)).toList();
+    assertTrue(runtimeJars.contains(mavenJar), "Maven jar should be in runtime jars");
+    assertFalse(runtimeJars.contains(local1Jar), "Local jar should NOT be in runtime jars");
+    assertFalse(runtimeJars.contains(local2Jar), "Local jar should NOT be in runtime jars");
+  }
+
+  /**
+   * Fixed scenario: Multi-module project with local jars first.
+   *
+   * <p>Given applicationClasspath = [local1.jar, local2.jar, maven.jar] with --local-app-jars =
+   * [local1.jar, local2.jar], the executor uses ALL local jars as application roots. Previously,
+   * only local1.jar (appCp.get(0)) would be used.
+   */
+  @Test
+  void allLocalJarsShouldBeApplicationRoots_multiModuleLocalFirst() {
+    // Simulate: applicationClasspath = [local1.jar, local2.jar, maven.jar]
+    Path local1Jar = Path.of("bazel-out/bin/services/api/libapi.jar");
+    Path local2Jar = Path.of("bazel-out/bin/services/domain/libdomain.jar");
+    Path mavenJar =
+        Path.of("external/maven/io/quarkus/quarkus-rest/3.33.1/quarkus-rest-3.33.1.jar");
+
+    List<Path> applicationClasspath = List.of(local1Jar, local2Jar, mavenJar);
+    List<Path> localAppJars = List.of(local1Jar, local2Jar);
+
+    QuarkifierConfig config =
+        new QuarkifierConfig(
+            applicationClasspath,
+            List.of(Path.of("deploy.jar")),
+            List.of(),
+            Path.of("/tmp/output"),
+            List.of(),
+            AugmentationMode.NORMAL,
+            null,
+            "test-app",
+            "1.0",
+            null,
+            null,
+            List.of(),
+            null,
+            List.of(),
+            List.of(),
+            null,
+            60,
+            localAppJars);
+
+    // Reproduce the executor's logic for determining application roots
+    List<Path> appCp = config.applicationClasspath();
+    List<Path> actualApplicationRoots =
+        config.localAppJars().isEmpty() ? List.of(appCp.get(0)) : config.localAppJars();
+
+    // Expected: BOTH local1 and local2 should be application roots
+    List<Path> expectedLocalJars = List.of(local1Jar, local2Jar);
+
+    assertEquals(
+        expectedLocalJars.size(),
+        actualApplicationRoots.size(),
+        "All local jars should be application roots. "
+            + "Expected "
+            + expectedLocalJars.size()
+            + " roots "
+            + expectedLocalJars
+            + " but got "
+            + actualApplicationRoots.size()
+            + " root(s): "
+            + actualApplicationRoots);
+
+    for (Path expectedLocalJar : expectedLocalJars) {
+      assertTrue(
+          actualApplicationRoots.contains(expectedLocalJar),
+          "Local jar "
+              + expectedLocalJar
+              + " should be in application roots, "
+              + "but actual roots are: "
+              + actualApplicationRoots);
+    }
+  }
+}

--- a/quarkifier/src/test/java/com/clementguillot/quarkifier/dev/DevModeLauncherTest.java
+++ b/quarkifier/src/test/java/com/clementguillot/quarkifier/dev/DevModeLauncherTest.java
@@ -31,7 +31,8 @@ class DevModeLauncherTest {
         List.of(),
         List.of(),
         null,
-        60);
+        60,
+        List.of());
   }
 
   @Test
@@ -107,7 +108,8 @@ class DevModeLauncherTest {
             List.of(),
             List.of(),
             null,
-            60);
+            60,
+            List.of());
 
     var context = DevModeLauncher.buildDevModeContext(config);
 
@@ -143,7 +145,8 @@ class DevModeLauncherTest {
             List.of(),
             List.of(),
             workspaceDir,
-            60);
+            60,
+            List.of());
 
     var context = DevModeLauncher.buildDevModeContext(config);
 
@@ -174,7 +177,8 @@ class DevModeLauncherTest {
             List.of(),
             List.of(),
             workspaceDir,
-            60);
+            60,
+            List.of());
 
     var context = DevModeLauncher.buildDevModeContext(config);
 
@@ -204,7 +208,8 @@ class DevModeLauncherTest {
             List.of("//pkg:lib"),
             List.of(),
             null,
-            60);
+            60,
+            List.of());
 
     var context = DevModeLauncher.buildDevModeContext(config);
 

--- a/quarkifier/src/test/java/com/clementguillot/quarkifier/model/QuarkusAppModelBuilderTest.java
+++ b/quarkifier/src/test/java/com/clementguillot/quarkifier/model/QuarkusAppModelBuilderTest.java
@@ -153,6 +153,40 @@ class QuarkusAppModelBuilderTest {
   }
 
   @Test
+  void buildRegistersAdditionalLocalAppJarsWithRuntimeAndDeploymentFlags() throws IOException {
+    Path appJar = createJar("app", "com.example", "myapp", "1.0");
+    Path secondLocalJar = createJar("domain", "com.example", "mydomain", "1.0");
+    Path depJar = createJar("dep", "io.quarkus", "quarkus-core", "3.33.1");
+
+    ApplicationModel model =
+        QuarkusAppModelBuilder.build(
+            List.of(appJar, secondLocalJar), List.of(depJar), List.of(), "myapp", "1.0");
+
+    // App artifact should be the first local jar
+    assertEquals("myapp", model.getAppArtifact().getArtifactId());
+
+    // Second local jar should be registered as a dependency with both runtime and deployment flags
+    ResolvedDependency secondLocalDep =
+        model.getDependencies().stream()
+            .filter(d -> "mydomain".equals(d.getArtifactId()))
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new AssertionError(
+                        "Second local jar 'mydomain' should be in model dependencies"));
+
+    assertTrue(
+        secondLocalDep.isFlagSet(DependencyFlags.RUNTIME_CP),
+        "Additional local app jar should have RUNTIME_CP flag");
+    assertTrue(
+        secondLocalDep.isFlagSet(DependencyFlags.DEPLOYMENT_CP),
+        "Additional local app jar should have DEPLOYMENT_CP flag");
+    assertEquals("com.example", secondLocalDep.getGroupId());
+    assertEquals("1.0", secondLocalDep.getVersion());
+    assertEquals("jar", secondLocalDep.getType());
+  }
+
+  @Test
   void deploymentSpiJarsAreNotMarkedRuntime() throws IOException {
     Path appJar = createJar("app", "com.example", "myapp", "1.0");
     Path spiJar = createJar("spi", "io.quarkus", "quarkus-vertx-deployment-spi", "3.33.1");

--- a/quarkifier/src/test/java/com/clementguillot/quarkifier/model/QuarkusAppModelBuilderTest.java
+++ b/quarkifier/src/test/java/com/clementguillot/quarkifier/model/QuarkusAppModelBuilderTest.java
@@ -30,7 +30,7 @@ class QuarkusAppModelBuilderTest {
     Path depJar = createJar("dep", "io.quarkus", "quarkus-core", "3.33.1");
 
     ApplicationModel model =
-        QuarkusAppModelBuilder.build(appJar, List.of(depJar), List.of(), "myapp", "1.0");
+        QuarkusAppModelBuilder.build(List.of(appJar), List.of(depJar), List.of(), "myapp", "1.0");
 
     assertEquals("jar", model.getAppArtifact().getType());
     for (ResolvedDependency dep : model.getDependencies()) {
@@ -53,7 +53,8 @@ class QuarkusAppModelBuilderTest {
                 + "<artifactId>quarkus-core</artifactId><version>3.33.1</version></dependency>");
 
     ApplicationModel model =
-        QuarkusAppModelBuilder.build(appJar, List.of(coreJar, restJar), List.of(), "myapp", "1.0");
+        QuarkusAppModelBuilder.build(
+            List.of(appJar), List.of(coreJar, restJar), List.of(), "myapp", "1.0");
 
     // Find quarkus-rest in the model and check its getDependencies()
     ResolvedDependency restDep =
@@ -85,7 +86,7 @@ class QuarkusAppModelBuilderTest {
 
     ApplicationModel model =
         QuarkusAppModelBuilder.build(
-            appJar, List.of(bufferJar, commonJar), List.of(), "myapp", "1.0");
+            List.of(appJar), List.of(bufferJar, commonJar), List.of(), "myapp", "1.0");
 
     ResolvedDependency bufferDep =
         model.getDependencies().stream()
@@ -119,7 +120,7 @@ class QuarkusAppModelBuilderTest {
 
     ApplicationModel model =
         QuarkusAppModelBuilder.build(
-            appJar, List.of(mainJar, configJar), List.of(), "myapp", "1.0");
+            List.of(appJar), List.of(mainJar, configJar), List.of(), "myapp", "1.0");
 
     ResolvedDependency mainDep =
         model.getDependencies().stream()
@@ -142,7 +143,7 @@ class QuarkusAppModelBuilderTest {
     Path arcJar = createExtensionJar("arc", "io.quarkus", "quarkus-arc", "3.33.1");
 
     ApplicationModel model =
-        QuarkusAppModelBuilder.build(appJar, List.of(arcJar), List.of(), "myapp", "1.0");
+        QuarkusAppModelBuilder.build(List.of(appJar), List.of(arcJar), List.of(), "myapp", "1.0");
 
     Collection<ArtifactCoords> appDeps = model.getAppArtifact().getDependencies();
     assertFalse(appDeps.isEmpty(), "root node should have direct dependencies");
@@ -157,7 +158,7 @@ class QuarkusAppModelBuilderTest {
     Path spiJar = createJar("spi", "io.quarkus", "quarkus-vertx-deployment-spi", "3.33.1");
 
     ApplicationModel model =
-        QuarkusAppModelBuilder.build(appJar, List.of(), List.of(spiJar), "myapp", "1.0");
+        QuarkusAppModelBuilder.build(List.of(appJar), List.of(), List.of(spiJar), "myapp", "1.0");
 
     ResolvedDependency spiDep =
         model.getDependencies().stream()

--- a/quarkifier/src/test/java/com/clementguillot/quarkifier/watcher/BazelFileWatcherTest.java
+++ b/quarkifier/src/test/java/com/clementguillot/quarkifier/watcher/BazelFileWatcherTest.java
@@ -37,7 +37,8 @@ class BazelFileWatcherTest {
         List.of("//pkg:lib"),
         List.of(),
         tempDir,
-        5);
+        5,
+        List.of());
   }
 
   @Test

--- a/quarkus/private/quarkus_app_impl.bzl
+++ b/quarkus/private/quarkus_app_impl.bzl
@@ -8,13 +8,17 @@ output, and generating a launcher script for `bazel run`.
 load("@rules_java//java/common:java_common.bzl", "java_common")
 load("@rules_java//java/common:java_info.bzl", "JavaInfo")
 load("//quarkus:providers.bzl", "QuarkusAppInfo")
-load("//quarkus/private:classpath_utils.bzl", "collect_runtime_classpath", "collect_source_jars")
+load("//quarkus/private:classpath_utils.bzl", "collect_runtime_classpath", "collect_source_jars", "is_local_artifact")
 
 def _quarkus_app_impl(ctx):
     if not ctx.attr.deps:
         fail("quarkus_app rule '{}' requires at least one dependency in 'deps'".format(ctx.label.name))
 
     runtime_classpath = collect_runtime_classpath(ctx.attr.deps)
+
+    # Partition into local workspace jars and external Maven jars
+    local_jars = [jar for jar in runtime_classpath.to_list() if is_local_artifact(jar)]
+
     source_jars = collect_source_jars(ctx.attr.deps)
     output_dir = ctx.actions.declare_directory(ctx.label.name + "-quarkus-app")
 
@@ -28,6 +32,8 @@ def _quarkus_app_impl(ctx):
     # Quarkifier CLI args
     args = ctx.actions.args()
     args.add_joined("--application-classpath", runtime_classpath, join_with = ":")
+    if local_jars:
+        args.add_joined("--local-app-jars", local_jars, join_with = ":")
     args.add_joined("--deployment-classpath", depset(transitive = [runtime_classpath, deployment_classpath]), join_with = ":")
     args.add("--output-dir", output_dir.path)
     args.add("--expected-quarkus-version", ctx.attr.quarkus_version)


### PR DESCRIPTION
- Closes: #75 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new CLI option --local-app-jars (colon-separated) to pass multiple local workspace JARs as application roots and serialize them back into CLI args.
  * Classpath is now partitioned into local application JARs and runtime JARs when configured.

* **Bug Fixes**
  * Validation now reports an error if provided local app JARs are not present in the application classpath.

* **Tests**
  * Added and expanded tests covering partitioning, round-trip config parsing/serialization, and model registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->