### PR TITLE
fix: verify quarkifier jar downloads with sha256

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,43 +22,16 @@ jobs:
   release:
     uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.7.0
     with:
-      release_files: rules_quarkus-*.tar.gz
+      # The quarkifier jars are built by release_prep.sh in the same run that
+      # assembles the source archive, so the archive's QUARKIFIER_SHA256 map
+      # (patched by release_prep.sh) always matches the released jars.
+      release_files: |
+        rules_quarkus-*.tar.gz
+        quarkifier-*.jar
       prerelease: false
       tag_name: ${{ inputs.tag_name || github.ref_name }}
-  quarkifier-jars:
-    needs: release
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          ref: ${{ inputs.tag_name || github.ref_name }}
-      - name: Build per-minor quarkifier deploy JARs
-        run: |
-          # Extract supported minor versions from versions.bzl
-          # Build each per-minor deploy jar and rename for release
-          for target in $(bazel query 'filter("quarkifier_[0-9]+_[0-9]+_deploy.jar$", //quarkifier:*)'); do
-            bazel build "$target"
-          done
-      - name: Prepare release assets
-        run: |
-          mkdir -p release-jars
-          tag="${{ inputs.tag_name || github.ref_name }}"
-          for jar in bazel-bin/quarkifier/quarkifier_*_deploy.jar; do
-            # quarkifier_3_27_deploy.jar → quarkifier-3.27-v0.1.0.jar
-            basename=$(basename "$jar")
-            minor=$(echo "$basename" | sed -E 's/quarkifier_([0-9]+)_([0-9]+)_deploy\.jar/\1.\2/')
-            cp "$jar" "release-jars/quarkifier-${minor}-${tag}.jar"
-          done
-      - name: Upload quarkifier JARs to release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          tag="${{ inputs.tag_name || github.ref_name }}"
-          for jar in release-jars/*.jar; do
-            gh release upload "$tag" "$jar" --clobber
-          done
   publish:
-    needs: quarkifier-jars
+    needs: release
     uses: ./.github/workflows/publish.yaml
     with:
       tag_name: ${{ inputs.tag_name || github.ref_name }}

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -14,9 +14,68 @@ ARCHIVE="rules_quarkus-$TAG.tar.gz"
 # Resolve the commit SHA for the tag
 COMMIT=$(git rev-list -n 1 ${TAG})
 
+# ---- Quarkifier deploy jars -------------------------------------------------
+# Build the per-minor jars, release them next to the source archive, and patch
+# their SHA-256 into the archive's versions.bzl. Chain of trust: the BCR
+# integrity pins the archive, the archive pins the jars — so the tool jar the
+# rules execute is verified end-to-end without needing the hashes in git
+# (they only exist once this script has built the jars).
+for target in $(bazel query 'filter("quarkifier_[0-9]+_[0-9]+_deploy.jar$", //quarkifier:*)'); do
+  bazel build "$target"
+done
+
+# sha256sum on Linux (CI); shasum on macOS for local dry-runs.
+_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+SHA_BLOCK="QUARKIFIER_SHA256 = {"
+CHECKSUM_ROWS=""
+for jar in bazel-bin/quarkifier/quarkifier_*_deploy.jar; do
+  base=$(basename "$jar")
+  # quarkifier_3_27_deploy.jar → 3.27
+  minor=$(echo "$base" | sed -E 's/quarkifier_([0-9]+)_([0-9]+)_deploy\.jar/\1.\2/')
+  released="quarkifier-${minor}-${TAG}.jar"
+  cp "$jar" "$released"
+  sha=$(_sha256 "$released")
+  SHA_BLOCK+=$'\n'"    \"${minor}\": \"${sha}\","
+  CHECKSUM_ROWS+="| \`${released}\` | \`${sha}\` |"$'\n'
+done
+SHA_BLOCK+=$'\n'"}"
+
+if [ -z "$CHECKSUM_ROWS" ]; then
+  echo "ERROR: no quarkifier deploy jars found; refusing to release an empty QUARKIFIER_SHA256 map" >&2
+  exit 1
+fi
+
+# ---- Source archive with checksums patched in -------------------------------
 # NB: configuration for 'git archive' is in /.gitattributes
-git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip > $ARCHIVE
-INTEGRITY=$(openssl dgst -sha256 -binary "$ARCHIVE" | openssl base64 -A)
+workdir=$(mktemp -d)
+git archive --format=tar --prefix="${PREFIX}/" "${TAG}" | tar -C "$workdir" -xf -
+
+VERSIONS_BZL="$workdir/$PREFIX/quarkus/private/versions.bzl"
+if ! grep -q '^QUARKIFIER_SHA256 = {}$' "$VERSIONS_BZL"; then
+  echo "ERROR: patch anchor 'QUARKIFIER_SHA256 = {}' not found in $VERSIONS_BZL" >&2
+  exit 1
+fi
+# The block is passed via the environment: ENVIRON values are byte-exact,
+# whereas awk -v would reinterpret backslash escape sequences.
+SHA_BLOCK="$SHA_BLOCK" awk \
+  '$0 == "QUARKIFIER_SHA256 = {}" { print ENVIRON["SHA_BLOCK"]; next } { print }' \
+  "$VERSIONS_BZL" > "$VERSIONS_BZL.tmp"
+mv "$VERSIONS_BZL.tmp" "$VERSIONS_BZL"
+
+# Deterministic tarball: stable entry order/ownership, commit timestamp for
+# mtimes (matching git archive's convention), no gzip timestamp.
+tar --create --directory "$workdir" \
+    --sort=name --owner=0 --group=0 --numeric-owner \
+    --mtime="@$(git log -1 --format=%ct "$TAG")" \
+    "$PREFIX" | gzip -n > "$ARCHIVE"
+rm -rf "$workdir"
 
 # Add generated API docs to the release, see https://github.com/bazelbuild/bazel-central-registry/issues/5593
 docs="$(mktemp -d)"; targets="$(mktemp)"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -71,6 +71,7 @@ The configured `quarkus_version` applies to every `quarkus_app`, generated `<nam
 | `lock_file` | `None` | Path to `maven_install.json` for extension auto-discovery |
 | `extension_group_prefixes` | `["io.quarkus", "io.quarkiverse."]` | Maven groupId prefixes identifying Quarkus extensions |
 | `quarkifier_source_dir` | `None` | Label in the rules_quarkus source dir for local dev builds |
+| `quarkifier_sha256` | `""` | SHA-256 pin for the quarkifier jar download. Released versions carry their own checksums, so this is only needed with `git_override`/`archive_override` (the build prints the hash to pin when verification is off) |
 
 ## 4. Create Your Application
 

--- a/quarkus/extensions.bzl
+++ b/quarkus/extensions.bzl
@@ -10,7 +10,7 @@ Produces a single generated repository (@rules_quarkus) containing:
   - deployment/: deployment jars resolved via Coursier
 """
 
-load("//quarkus/private:versions.bzl", "COURSIER_SHA256", "COURSIER_URL", "GITHUB_OWNER", "GITHUB_REPO", "MAVEN_CENTRAL", "RULES_VERSION", "SUPPORTED_VERSIONS")
+load("//quarkus/private:versions.bzl", "COURSIER_SHA256", "COURSIER_URL", "GITHUB_OWNER", "GITHUB_REPO", "MAVEN_CENTRAL", "QUARKIFIER_SHA256", "RULES_VERSION", "SUPPORTED_VERSIONS")
 
 _DEFAULT_EXTENSION_GROUP_PREFIXES = ["io.quarkus", "io.quarkiverse."]
 
@@ -201,11 +201,34 @@ def _build_quarkifier_from_source(rctx):
     rctx.symlink(deploy_jar, "quarkifier/tool.jar")
 
 def _resolve_quarkifier_tool(rctx):
-    """Materializes quarkifier/tool.jar from a local build or a release download."""
+    """Materializes quarkifier/tool.jar from a local build or a release download.
+
+    Release downloads are verified against the checksum patched into
+    QUARKIFIER_SHA256 by release_prep.sh (or supplied by the user via
+    quarkus.toolchain(quarkifier_sha256 = ...)). Without a checksum the
+    download still works, but the computed hash is printed so it can be
+    pinned — the jar is executable code run by build actions, dev mode, and
+    tests, so unverified use should be a deliberate choice.
+    """
     if rctx.attr.quarkifier_source_dir:
         _build_quarkifier_from_source(rctx)
     elif rctx.attr.quarkifier_url:
-        rctx.download(url = rctx.attr.quarkifier_url, output = "quarkifier/tool.jar")
+        if rctx.attr.quarkifier_sha256:
+            rctx.download(
+                url = rctx.attr.quarkifier_url,
+                output = "quarkifier/tool.jar",
+                sha256 = rctx.attr.quarkifier_sha256,
+            )
+        else:
+            result = rctx.download(url = rctx.attr.quarkifier_url, output = "quarkifier/tool.jar")
+
+            # buildifier: disable=print
+            print((
+                "\nWARNING: rules_quarkus downloaded the quarkifier tool jar without " +
+                "checksum verification:\n    {url}\n" +
+                "Pin it in MODULE.bazel:\n" +
+                "    quarkus.toolchain(quarkifier_sha256 = \"{sha}\", ...)\n"
+            ).format(url = rctx.attr.quarkifier_url, sha = result.sha256))
     else:
         fail("Either quarkifier_source_dir or quarkifier_url must be set")
 
@@ -618,6 +641,7 @@ _rules_quarkus_repo = repository_rule(
             doc = "bin/java of the hermetic JDK used to run Coursier when the host has no usable JVM.",
         ),
         "quarkifier_build_target": attr.string(doc = "Bazel target for the per-minor deploy jar (local build mode)."),
+        "quarkifier_sha256": attr.string(doc = "SHA-256 checksum for the quarkifier jar download (release mode). Empty disables verification."),
         "quarkifier_source_dir": attr.label(doc = "Label in the rules_quarkus source dir (local build mode)."),
         "quarkifier_url": attr.string(doc = "URL to download the quarkifier jar from (release mode)."),
         "quarkus_version": attr.string(mandatory = True, doc = "Quarkus version."),
@@ -644,6 +668,9 @@ def _quarkifier_repo_attrs(tc, minor):
             minor,
             release_tag,
         ),
+        # User-supplied pin wins; otherwise the checksum patched into the
+        # release archive by release_prep.sh (empty in the git tree).
+        "quarkifier_sha256": tc.quarkifier_sha256 or QUARKIFIER_SHA256.get(minor, ""),
     }
 
 def _quarkus_impl(mctx):
@@ -676,6 +703,15 @@ _toolchain_tag = tag_class(
         ),
         "lock_file": attr.label(
             doc = "Path to maven_install.json for auto-discovering Quarkus extensions.",
+        ),
+        "quarkifier_sha256": attr.string(
+            doc = """\
+SHA-256 checksum of the quarkifier release jar, overriding the checksum
+bundled in the release archive. Normally not needed: released versions carry
+their own checksums. Set it when consuming rules_quarkus via git_override or
+archive_override, where the bundled checksum map is empty — the build prints
+the hash to pin when verification is disabled.
+""",
         ),
         "quarkifier_source_dir": attr.label(
             doc = """\

--- a/quarkus/private/versions.bzl
+++ b/quarkus/private/versions.bzl
@@ -18,6 +18,25 @@ RULES_VERSION = "0.0.0" if _RULES_VERSION.startswith("$Format") else _RULES_VERS
 GITHUB_OWNER = "clementguillot"
 GITHUB_REPO = "rules_quarkus"
 
+# SHA-256 checksums of the per-minor quarkifier release jars, keyed by minor
+# version (e.g. "3.33").
+#
+# Intentionally EMPTY in the git tree: the jar hashes only exist once the
+# release workflow has built the jars. release_prep.sh builds them, computes
+# the checksums, and patches this map into the copy of this file that ships
+# inside the release source archive — so the released tarball deliberately
+# differs from `git archive <tag>` on this one declaration (same idea as the
+# export-subst RULES_VERSION above). The BCR integrity of the archive then
+# transitively pins the jars.
+#
+# When the map is empty (git checkout, or a custom quarkifier_url without
+# quarkus.toolchain(quarkifier_sha256 = ...)), the download is unverified and
+# the module extension prints the hash to pin.
+#
+# The exact line `QUARKIFIER_SHA256 = {}` is the patch anchor for
+# release_prep.sh — do not reformat it.
+QUARKIFIER_SHA256 = {}
+
 # Maven Central URL for Coursier-based deployment artifact resolution.
 MAVEN_CENTRAL = "https://repo1.maven.org/maven2"
 


### PR DESCRIPTION
- Closes: #108 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added checksum verification support for Quarkifier downloads, with an option to pin a SHA-256 value in configuration.
  * Release builds now include precomputed checksums for bundled Quarkifier artifacts.

* **Bug Fixes**
  * Improved release packaging so published artifacts are assembled more reliably and consistently.

* **Documentation**
  * Updated the getting-started guide with the new checksum pinning option and when it’s needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->