### PR TITLE
fix(rules): fail when zero tests execute

### DIFF
--- a/e2e/smoke/BUILD
+++ b/e2e/smoke/BUILD
@@ -1,6 +1,7 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_java//java:java_library.bzl", "java_library")
 load("@rules_quarkus//quarkus:defs.bzl", "quarkus_app", "quarkus_test")
+load(":expect_test_failure.bzl", "expect_test_failure_test")
 
 java_library(
     name = "lib",
@@ -27,7 +28,10 @@ quarkus_app(
 java_library(
     name = "test_lib",
     testonly = True,
-    srcs = glob(["src/test/java/**/*.java"]),
+    srcs = glob(
+        ["src/test/java/**/*.java"],
+        exclude = ["src/test/java/smoke/EmptyTest.java"],
+    ),
     # //big reuses the test sources for the E2BIG regression targets.
     visibility = ["//big:__pkg__"],
     deps = [
@@ -54,6 +58,43 @@ build_test(
     targets = [
         ":app",
     ],
+)
+
+# --- fail_if_no_tests smoke tests (issue #125) ---
+#
+# EmptyTest.java is a @QuarkusTest with zero @Test methods.
+java_library(
+    name = "empty_test_lib",
+    testonly = True,
+    srcs = ["src/test/java/smoke/EmptyTest.java"],
+    deps = [
+        ":lib",
+        "@maven//:io_quarkus_quarkus_junit",
+        "@maven//:org_junit_jupiter_junit_jupiter",
+        "@maven//:org_junit_jupiter_junit_jupiter_api",
+        "@maven//:org_junit_platform_junit_platform_console_standalone",
+        "@maven//:org_junit_platform_junit_platform_launcher",
+    ],
+)
+
+# Zero tests + strict mode (default) — must fail.
+quarkus_test(
+    name = "empty_test_strict",
+    tags = ["manual"],
+    deps = [":empty_test_lib"],
+)
+
+# Wraps empty_test_strict and asserts it fails. This target runs in CI.
+expect_test_failure_test(
+    name = "empty_test_strict_fails",
+    target = ":empty_test_strict",
+)
+
+# Zero tests + lenient mode — must pass. Runs in CI directly.
+quarkus_test(
+    name = "empty_test_lenient",
+    fail_if_no_tests = False,
+    deps = [":empty_test_lib"],
 )
 
 # Verifies the extension publish artifacts (jars + POMs) build for both halves.

--- a/e2e/smoke/expect_test_failure.bzl
+++ b/e2e/smoke/expect_test_failure.bzl
@@ -1,0 +1,45 @@
+"""Rule that asserts a test target fails at execution time.
+
+Use this to verify that a test correctly detects and reports failures,
+e.g. a quarkus_test with zero tests should fail when fail_if_no_tests=True.
+"""
+
+def _expect_test_failure_impl(ctx):
+    target = ctx.attr.target
+    target_executable = target[DefaultInfo].files_to_run.executable
+
+    # Build a wrapper script that runs the target and asserts non-zero exit.
+    script = ctx.actions.declare_file(ctx.label.name + "_expect_failure.sh")
+    ctx.actions.write(
+        output = script,
+        content = """\
+#!/usr/bin/env bash
+set -uo pipefail
+if "{target}" "$@" 2>&1; then
+  echo "FAIL: expected target to fail but it exited 0" >&2
+  exit 1
+fi
+echo "PASS: target correctly failed"
+exit 0
+""".format(target = target_executable.short_path),
+        is_executable = True,
+    )
+
+    runfiles = ctx.runfiles(files = [target_executable])
+    runfiles = runfiles.merge(target[DefaultInfo].default_runfiles)
+
+    return [DefaultInfo(executable = script, runfiles = runfiles)]
+
+expect_test_failure_test = rule(
+    implementation = _expect_test_failure_impl,
+    test = True,
+    attrs = {
+        "target": attr.label(
+            mandatory = True,
+            executable = True,
+            cfg = "target",
+            doc = "Test target expected to fail at execution time.",
+        ),
+    },
+    doc = "A test that passes when the wrapped target fails at execution time.",
+)

--- a/e2e/smoke/src/test/java/smoke/EmptyTest.java
+++ b/e2e/smoke/src/test/java/smoke/EmptyTest.java
@@ -1,0 +1,7 @@
+package smoke;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+/** Intentionally has no @Test methods. Used to verify fail_if_no_tests behavior. */
+@QuarkusTest
+class EmptyTest {}

--- a/quarkus/private/classpath_utils.bzl
+++ b/quarkus/private/classpath_utils.bzl
@@ -7,6 +7,7 @@ QuarkusExtensionDeploymentClasspathInfo = provider(
     doc = "Transitive deployment classpath contributed by local Quarkus extensions.",
     fields = {
         "deployment_classpath": "Depset of deployment classpath jars.",
+        "extension_runtime_jars": "Depset of extension runtime jars (to exclude from app roots).",
     },
 )
 
@@ -17,26 +18,35 @@ def _as_list(value):
 
 def _collect_aspect_attr_classpaths(ctx, attr_name):
     if not hasattr(ctx.rule.attr, attr_name):
-        return []
+        return [], []
 
     classpaths = []
+    ext_rt_jars = []
     for dep in _as_list(getattr(ctx.rule.attr, attr_name)):
         if QuarkusExtensionDeploymentClasspathInfo in dep:
             classpaths.append(dep[QuarkusExtensionDeploymentClasspathInfo].deployment_classpath)
-    return classpaths
+            ext_rt_jars.append(dep[QuarkusExtensionDeploymentClasspathInfo].extension_runtime_jars)
+    return classpaths, ext_rt_jars
 
 def _quarkus_extension_deployment_classpath_aspect_impl(target, ctx):
     classpaths = []
+    ext_rt_jars = []
     if QuarkusExtensionInfo in target:
         classpaths.append(target[QuarkusExtensionInfo].deployment_classpath)
 
-    classpaths.extend(_collect_aspect_attr_classpaths(ctx, "deps"))
-    classpaths.extend(_collect_aspect_attr_classpaths(ctx, "runtime_deps"))
-    classpaths.extend(_collect_aspect_attr_classpaths(ctx, "exports"))
+        # The extension's own output jar is an extension runtime jar.
+        if JavaInfo in target:
+            ext_rt_jars.append(depset(target[JavaInfo].runtime_output_jars))
+
+    for attr_name in ("deps", "runtime_deps", "exports"):
+        cps, rts = _collect_aspect_attr_classpaths(ctx, attr_name)
+        classpaths.extend(cps)
+        ext_rt_jars.extend(rts)
 
     return [
         QuarkusExtensionDeploymentClasspathInfo(
             deployment_classpath = depset(transitive = classpaths),
+            extension_runtime_jars = depset(transitive = ext_rt_jars),
         ),
     ]
 
@@ -85,6 +95,20 @@ def collect_extension_deployment_classpath(deps):
             transitive.append(dep[QuarkusExtensionDeploymentClasspathInfo].deployment_classpath)
     return depset(transitive = transitive)
 
+def collect_extension_runtime_jars(deps):
+    """Collects extension runtime jars from deps (to exclude from app roots).
+
+    Args:
+        deps: List of targets that may provide QuarkusExtensionDeploymentClasspathInfo
+    Returns:
+        A depset of extension runtime jar Files.
+    """
+    transitive = []
+    for dep in deps:
+        if QuarkusExtensionDeploymentClasspathInfo in dep:
+            transitive.append(dep[QuarkusExtensionDeploymentClasspathInfo].extension_runtime_jars)
+    return depset(transitive = transitive)
+
 def collect_deployment_classpath(deployment_deps, deps):
     """Builds the full Quarkus deployment classpath.
 
@@ -102,7 +126,7 @@ def collect_deployment_classpath(deployment_deps, deps):
         collect_extension_deployment_classpath(deps),
     ])
 
-def collect_local_app_jars(deps, runtime_classpath):
+def collect_local_app_jars(deps, runtime_classpath, exclude_jars = None):
     """Returns local workspace jars with direct-dep output jars ordered first.
 
     The quarkifier treats the first `--local-app-jars` entry as the application
@@ -114,20 +138,26 @@ def collect_local_app_jars(deps, runtime_classpath):
     Args:
         deps: List of direct dep targets that may provide JavaInfo.
         runtime_classpath: Depset of transitive runtime jars.
+        exclude_jars: Optional depset of jars to exclude (e.g. extension runtime jars).
     Returns:
         A deduplicated, direct-first ordered list of local jar Files.
     """
+    excluded_paths = {}
+    if exclude_jars:
+        for jar in exclude_jars.to_list():
+            excluded_paths[jar.path] = True
+
     seen = {}
     ordered = []
     for dep in deps:
         if JavaInfo not in dep or dep.label.workspace_name:
             continue
         for jar in dep[JavaInfo].runtime_output_jars:
-            if jar.path not in seen:
+            if jar.path not in seen and jar.path not in excluded_paths:
                 seen[jar.path] = True
                 ordered.append(jar)
     for jar in runtime_classpath.to_list():
-        if is_local_artifact(jar) and jar.path not in seen:
+        if is_local_artifact(jar) and jar.path not in seen and jar.path not in excluded_paths:
             seen[jar.path] = True
             ordered.append(jar)
     return ordered

--- a/quarkus/private/quarkus_test_impl.bzl
+++ b/quarkus/private/quarkus_test_impl.bzl
@@ -14,7 +14,7 @@ that jar paths in the ApplicationModel match the actual runfiles locations.
 load("@bazel_skylib//lib:shell.bzl", "shell")
 load("@rules_java//java/common:java_common.bzl", "java_common")
 load("@rules_java//java/common:java_info.bzl", "JavaInfo")
-load("//quarkus/private:classpath_utils.bzl", "collect_deployment_classpath", "collect_local_app_jars", "collect_runtime_classpath", "quarkus_extension_deployment_classpath_aspect", "write_runfiles_paths_file")
+load("//quarkus/private:classpath_utils.bzl", "collect_deployment_classpath", "collect_extension_runtime_jars", "collect_local_app_jars", "collect_runtime_classpath", "quarkus_extension_deployment_classpath_aspect", "write_runfiles_paths_file")
 
 def _build_test_args(test_packages, test_classes, fail_if_no_tests):
     """Builds JUnit ConsoleLauncher CLI arguments."""
@@ -38,9 +38,12 @@ def _quarkus_test_impl(ctx):
     # Runtime classpath (for both JUnit -cp and quarkifier --application-classpath),
     # deployment classpath (for quarkifier only, NOT on JUnit -cp), and the
     # user-built jars Quarkus must scan (comma-separated, for OUTPUT_SOURCES_DIR).
+    # Extension runtime jars are excluded from direct_jars: leaving them as app
+    # roots exposes their @ConfigRoot classes to both classloaders (SRCFG00027).
     cp_file = write_runfiles_paths_file(ctx, "_cp.txt", runtime_classpath, ":")
     deploy_cp_file = write_runfiles_paths_file(ctx, "_deploy_cp.txt", deploy_classpath, ":")
-    direct_jars_file = write_runfiles_paths_file(ctx, "_direct_jars.txt", collect_local_app_jars(ctx.attr.deps, runtime_classpath), ",")
+    ext_rt_jars = collect_extension_runtime_jars(ctx.attr.deps)
+    direct_jars_file = write_runfiles_paths_file(ctx, "_direct_jars.txt", collect_local_app_jars(ctx.attr.deps, runtime_classpath, ext_rt_jars), ",")
 
     tool_jar = ctx.file.quarkifier_tool
     java_runtime = ctx.attr._java_runtime[java_common.JavaRuntimeInfo]

--- a/quarkus/private/quarkus_test_impl.bzl
+++ b/quarkus/private/quarkus_test_impl.bzl
@@ -16,9 +16,11 @@ load("@rules_java//java/common:java_common.bzl", "java_common")
 load("@rules_java//java/common:java_info.bzl", "JavaInfo")
 load("//quarkus/private:classpath_utils.bzl", "collect_deployment_classpath", "collect_local_app_jars", "collect_runtime_classpath", "quarkus_extension_deployment_classpath_aspect", "write_runfiles_paths_file")
 
-def _build_test_args(test_packages, test_classes):
+def _build_test_args(test_packages, test_classes, fail_if_no_tests):
     """Builds JUnit ConsoleLauncher CLI arguments."""
-    args = ["execute", "--fail-if-no-tests"]
+    args = ["execute"]
+    if fail_if_no_tests:
+        args.append("--fail-if-no-tests")
     for pkg in test_packages:
         args.append("--select-package=" + pkg)
     for cls in test_classes:
@@ -55,7 +57,8 @@ def _quarkus_test_impl(ctx):
             "%{java_home}": java_runtime.java_home_runfiles_path,
             "%{jvm_flags}": " ".join([shell.quote(f) for f in ctx.attr.jvm_flags]),
             "%{quarkus_version}": ctx.attr.quarkus_version,
-            "%{test_args}": _build_test_args(ctx.attr.test_packages, ctx.attr.test_classes),
+            "%{test_args}": _build_test_args(ctx.attr.test_packages, ctx.attr.test_classes, ctx.attr.fail_if_no_tests),
+            "%{fail_if_no_tests}": "true" if ctx.attr.fail_if_no_tests else "false",
             "%{tool_jar}": tool_jar.short_path,
             "%{workspace}": ctx.workspace_name,
         },
@@ -81,6 +84,10 @@ quarkus_test = rule(
             aspects = [quarkus_extension_deployment_classpath_aspect],
             providers = [JavaInfo],
             doc = "Test java_library targets. Transitive deps (app code, quarkus-junit, etc.) are included automatically.",
+        ),
+        "fail_if_no_tests": attr.bool(
+            default = True,
+            doc = "Fail the test if zero tests are discovered/executed. Set to False for targets where an empty test set is acceptable.",
         ),
         "jvm_flags": attr.string_list(
             doc = "JVM flags passed to the java command when running tests.",

--- a/quarkus/private/test_launcher.sh.tpl
+++ b/quarkus/private/test_launcher.sh.tpl
@@ -135,11 +135,22 @@ JUNIT_EXIT=$?
 
 rm -f "$JAVA_ARGS_FILE" "$APP_CP_FILE"
 
-# Check XML reports for the real test result.
+# Determine final exit code.
+# ConsoleLauncher exits non-zero on Quarkus session-shutdown exceptions
+# (ClassCastException in ConfigLauncherSession) even when all tests
+# pass. The XML report is the source of truth for pass/fail, with one guard:
+# if zero tests actually executed, that's a failure (misconfigured test_packages,
+# no @Test methods, etc.) regardless of what the exit code says.
 if ls "$REPORTS_DIR"/TEST-*.xml >/dev/null 2>&1; then
   if grep -q 'failures="[1-9]' "$REPORTS_DIR"/TEST-*.xml 2>/dev/null || \
      grep -q 'errors="[1-9]' "$REPORTS_DIR"/TEST-*.xml 2>/dev/null; then
     rm -rf "$REPORTS_DIR"
+    exit 1
+  fi
+  if [ "%{fail_if_no_tests}" = "true" ] && \
+     ! grep -q 'tests="[1-9]' "$REPORTS_DIR"/TEST-*.xml 2>/dev/null; then
+    rm -rf "$REPORTS_DIR"
+    echo "ERROR: Zero tests executed (check test_packages / test_classes configuration)" >&2
     exit 1
   fi
   rm -rf "$REPORTS_DIR"


### PR DESCRIPTION
- Closes: #125 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable `fail-if-no-tests` behavior for test runs (strict vs lenient when no tests are discovered).
  * Added end-to-end smoke coverage for zero-test behavior in both strict (expected to fail) and lenient (expected to pass) modes.
* **Bug Fixes**
  * Improved test launcher pass/fail determination by relying on generated test report results, reducing discrepancies caused by launcher exit behavior.
  * Ensures strict zero-test runs fail based on report contents, while lenient runs succeed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->