### PR TITLE
fix(quarkifier): preserve augmented jar content in `assembleLibDirectories`

### DIFF
--- a/quarkifier/src/main/java/com/clementguillot/quarkifier/augmentation/FastJarAssembler.java
+++ b/quarkifier/src/main/java/com/clementguillot/quarkifier/augmentation/FastJarAssembler.java
@@ -9,8 +9,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.jar.JarFile;
 import java.util.jar.JarOutputStream;
@@ -34,9 +36,11 @@ import org.jboss.logging.Logger;
  *       classpath
  * </ol>
  */
+@SuppressWarnings({"PMD.GodClass", "PMD.TooManyMethods"})
 public final class FastJarAssembler {
 
   private static final String JAR_EXTENSION = ".jar";
+  private static final Set<String> EXCLUDED_ARTIFACT_IDS = Set.of("quarkus-ide-launcher");
   private static final Logger LOGGER = Logger.getLogger(FastJarAssembler.class);
 
   private FastJarAssembler() {}
@@ -66,13 +70,14 @@ public final class FastJarAssembler {
   }
 
   /**
-   * Copies runtime jars into {@code lib/boot/} or {@code lib/main/} based on the {@code
-   * CLASSLOADER_RUNNER_PARENT_FIRST} flag from extension properties.
+   * Normalizes jar filenames in {@code lib/boot/} and {@code lib/main/} to Maven-convention names,
+   * preserving the jar content that Quarkus augmentation placed (which may have removed entries via
+   * {@code RemovedResourceBuildItem} or class-removing transformers).
    *
-   * <p>First clears any jars placed by the Quarkus augmentation step (which may use raw classpath
-   * filenames with {@code processed_} prefixes), then copies jars with clean Maven-convention
-   * names. Deduplicates by full GAV so that the same artifact from different sources is copied once
-   * without dropping unrelated artifacts that share an artifactId and version.
+   * <p>Strategy: rename augmented jars in-place, reclassify between boot/main based on the model's
+   * {@code CLASSLOADER_RUNNER_PARENT_FIRST} flag, and fill in any jars not placed by augmentation
+   * from the original runtime classpath. This avoids overwriting filtered jars with pristine
+   * originals.
    */
   static void assembleLibDirectories(Path outputDir, List<Path> runtimeJars, ApplicationModel model)
       throws IOException {
@@ -80,37 +85,131 @@ public final class FastJarAssembler {
     Path quarkusAppDir = resolveQuarkusAppDir(outputDir);
     Path libBoot = quarkusAppDir.resolve("lib").resolve("boot");
     Path libMain = quarkusAppDir.resolve("lib").resolve("main");
-
-    // Clear jars placed by Quarkus augmentation (they use raw classpath filenames
-    // which may include "processed_" prefixes and inconsistent naming).
-    clearJars(libBoot);
-    clearJars(libMain);
     Files.createDirectories(libBoot);
     Files.createDirectories(libMain);
 
-    Set<String> bootArtifactIds = new HashSet<>();
+    Set<String> bootArtifactIds = collectBootArtifactIds(model);
+    Map<String, MavenCoordinateParser.Coordinates> coordsByArtVer =
+        buildRuntimeCoordsLookup(runtimeJars);
+
+    Set<String> presentKeys = new HashSet<>();
+    renameAugmentedJars(libBoot, libMain, bootArtifactIds, coordsByArtVer, presentKeys);
+    fillMissingJars(runtimeJars, libBoot, libMain, bootArtifactIds, presentKeys);
+  }
+
+  /** Collects artifact IDs that belong in the boot classloader. */
+  private static Set<String> collectBootArtifactIds(ApplicationModel model) {
+    Set<String> ids = new HashSet<>();
     for (var dep : model.getDependencies()) {
       if (dep.isFlagSet(DependencyFlags.CLASSLOADER_RUNNER_PARENT_FIRST)) {
-        bootArtifactIds.add(dep.getArtifactId());
+        ids.add(dep.getArtifactId());
       }
     }
-    bootArtifactIds.add("quarkus-bootstrap-runner");
-    bootArtifactIds.add("quarkus-classloader-commons");
+    ids.add("quarkus-bootstrap-runner");
+    ids.add("quarkus-classloader-commons");
+    return ids;
+  }
 
-    Set<String> copiedKeys = new HashSet<>();
-    Set<String> excludedArtifactIds = Set.of("quarkus-ide-launcher"); // IDE/dev-mode only
+  /**
+   * Builds a lookup from {@code artifactId:version} → full coordinates from the runtime classpath.
+   * Augmented jars in lib/ often lack a groupId in their filename, so we match on
+   * artifactId:version and recover the groupId from the classpath entry.
+   */
+  private static Map<String, MavenCoordinateParser.Coordinates> buildRuntimeCoordsLookup(
+      List<Path> runtimeJars) {
+    Map<String, MavenCoordinateParser.Coordinates> lookup = new HashMap<>();
+    for (Path jar : runtimeJars) {
+      var coords = MavenCoordinateParser.parse(jar);
+      lookup.putIfAbsent(coords.artifactId() + ":" + coords.version(), coords);
+    }
+    return lookup;
+  }
+
+  /**
+   * Renames augmented jars already in lib/ to Maven-convention names, reclassifying between boot
+   * and main as needed. Populates {@code presentKeys} with GAVs already handled.
+   */
+  private static void renameAugmentedJars(
+      Path libBoot,
+      Path libMain,
+      Set<String> bootArtifactIds,
+      Map<String, MavenCoordinateParser.Coordinates> coordsByArtVer,
+      Set<String> presentKeys)
+      throws IOException {
+
+    List<Path> snapshot = new ArrayList<>();
+    for (Path dir : List.of(libBoot, libMain)) {
+      if (!Files.isDirectory(dir)) {
+        continue;
+      }
+      try (var s = Files.list(dir)) {
+        s.filter(p -> p.toString().endsWith(JAR_EXTENSION)).forEach(snapshot::add);
+      }
+    }
+    for (Path jar : snapshot) {
+      renameOneAugmentedJar(jar, libBoot, libMain, bootArtifactIds, coordsByArtVer, presentKeys);
+    }
+  }
+
+  /** Renames (or deletes) a single augmented jar to its Maven-convention location. */
+  private static void renameOneAugmentedJar(
+      Path jar,
+      Path libBoot,
+      Path libMain,
+      Set<String> bootArtifactIds,
+      Map<String, MavenCoordinateParser.Coordinates> coordsByArtVer,
+      Set<String> presentKeys)
+      throws IOException {
+
+    var coords = MavenCoordinateParser.parse(jar);
+    var fullCoords =
+        coordsByArtVer.getOrDefault(coords.artifactId() + ":" + coords.version(), coords);
+    String dedupeKey =
+        fullCoords.groupId() + ":" + fullCoords.artifactId() + ":" + fullCoords.version();
+
+    if (EXCLUDED_ARTIFACT_IDS.contains(fullCoords.artifactId())
+        || presentKeys.contains(dedupeKey)) {
+      deleteQuietly(jar);
+      return;
+    }
+    presentKeys.add(dedupeKey);
+
+    String mavenName =
+        fullCoords.groupId()
+            + "."
+            + fullCoords.artifactId()
+            + "-"
+            + fullCoords.version()
+            + JAR_EXTENSION;
+    Path targetDir = bootArtifactIds.contains(fullCoords.artifactId()) ? libBoot : libMain;
+    Path targetPath = targetDir.resolve(mavenName);
+
+    if (!jar.equals(targetPath)) {
+      makeWritableIfExists(jar);
+      Files.move(jar, targetPath, StandardCopyOption.REPLACE_EXISTING);
+    }
+  }
+
+  /**
+   * Copies jars from the runtime classpath that augmentation didn't place (e.g. jars with no
+   * Quarkus dependency mapping).
+   */
+  private static void fillMissingJars(
+      List<Path> runtimeJars,
+      Path libBoot,
+      Path libMain,
+      Set<String> bootArtifactIds,
+      Set<String> presentKeys)
+      throws IOException {
 
     for (Path jar : runtimeJars) {
       var coords = MavenCoordinateParser.parse(jar);
       String dedupeKey = coords.groupId() + ":" + coords.artifactId() + ":" + coords.version();
 
-      if (copiedKeys.contains(dedupeKey)) {
+      if (presentKeys.contains(dedupeKey) || EXCLUDED_ARTIFACT_IDS.contains(coords.artifactId())) {
         continue;
       }
-      if (excludedArtifactIds.contains(coords.artifactId())) {
-        continue;
-      }
-      copiedKeys.add(dedupeKey);
+      presentKeys.add(dedupeKey);
 
       String mavenName =
           coords.groupId() + "." + coords.artifactId() + "-" + coords.version() + JAR_EXTENSION;
@@ -138,9 +237,6 @@ public final class FastJarAssembler {
         if (!Files.isRegularFile(resource)) {
           continue;
         }
-        // Resource paths are flattened to their file name; a full
-        // structure-preserving layout would need a base-dir concept the CLI
-        // does not have. Surface collisions instead of dropping silently.
         String entryName = resource.getFileName().toString();
         if (addedEntries.contains(entryName)) {
           LOGGER.warnf(
@@ -165,10 +261,6 @@ public final class FastJarAssembler {
    * <p>Jars in {@code lib/boot/} are registered as parent-first (loaded by the boot classloader),
    * which is critical for the JBoss LogManager to intercept JUL before any other logging framework
    * initializes. All other jars are indexed normally for the RunnerClassLoader.
-   *
-   * @param outputDir the augmentation output directory
-   * @param mainClass the fully-qualified main class name, or {@code null} to use the default {@code
-   *     io.quarkus.runner.GeneratedMain}
    */
   static void regenerateApplicationDat(Path outputDir, String mainClass) throws IOException {
     Path quarkusAppDir = resolveQuarkusAppDir(outputDir).toAbsolutePath();
@@ -281,43 +373,34 @@ public final class FastJarAssembler {
     return Files.isDirectory(quarkusAppDir) ? quarkusAppDir : outputDir;
   }
 
-  /**
-   * Makes a file writable, throwing {@link IOException} if the permission change fails.
-   *
-   * <p>Quarkus augmentation output files are sometimes read-only. We need to make them writable
-   * before overwriting or deleting them.
-   */
+  /** Makes a file writable, throwing {@link IOException} if the permission change fails. */
   private static void makeWritable(Path file) throws IOException {
     if (!file.toFile().setWritable(true)) {
       throw new IOException("Cannot make file writable: " + file);
     }
   }
 
-  /** Removes all .jar files from a directory. */
-  private static void clearJars(Path dir) throws IOException {
-    if (!Files.isDirectory(dir)) {
-      return;
+  /** Deletes a file, making it writable first if needed. Logs and continues on failure. */
+  private static void deleteQuietly(Path file) {
+    try {
+      Files.delete(file);
+    } catch (IOException e) {
+      if (!file.toFile().setWritable(true)) {
+        LOGGER.warnf("Cannot make file writable, skipping delete: %s", file);
+        return;
+      }
+      try {
+        Files.delete(file);
+      } catch (IOException retryFailed) {
+        LOGGER.warnf("Cannot delete file after making writable: %s", file);
+      }
     }
-    try (var stream = Files.list(dir)) {
-      stream
-          .filter(p -> p.toString().endsWith(JAR_EXTENSION))
-          .forEach(
-              p -> {
-                try {
-                  Files.delete(p);
-                } catch (IOException e) {
-                  // Retry after making writable — Quarkus output jars may be read-only.
-                  if (!p.toFile().setWritable(true)) {
-                    LOGGER.warnf("Cannot make file writable, skipping delete: %s", p);
-                    return;
-                  }
-                  try {
-                    Files.delete(p);
-                  } catch (IOException retryFailed) {
-                    LOGGER.warnf("Cannot delete file after making writable: %s", p);
-                  }
-                }
-              });
+  }
+
+  /** Makes a file writable if it exists. No-op for missing files. */
+  private static void makeWritableIfExists(Path file) throws IOException {
+    if (Files.exists(file) && !file.toFile().setWritable(true)) {
+      throw new IOException("Cannot make file writable: " + file);
     }
   }
 }

--- a/quarkifier/src/test/java/com/clementguillot/quarkifier/augmentation/FastJarAssemblerTest.java
+++ b/quarkifier/src/test/java/com/clementguillot/quarkifier/augmentation/FastJarAssemblerTest.java
@@ -93,11 +93,16 @@ class FastJarAssemblerTest {
   }
 
   @Test
-  void assembleLibDirectories_clearsStaleAugmentationJars() throws IOException {
+  void assembleLibDirectories_renamesStaleAugmentationJars() throws IOException {
     Path outputDir = quarkusAppDir();
     Path libMain = outputDir.resolve("quarkus-app/lib/main");
     Files.createDirectories(libMain);
-    Files.writeString(libMain.resolve("processed_quarkus-arc-3.33.2.jar"), "stale");
+    // Simulate a jar placed by augmentation with a "processed_" filename.
+    // Write it in a Maven-layout temp dir so MavenCoordinateParser can resolve its GAV.
+    Path augmentedJar =
+        createJarAt(
+            "lib-stage/io/quarkus/quarkus-arc/3.33.2", "io.quarkus", "quarkus-arc", "3.33.2");
+    Files.copy(augmentedJar, libMain.resolve("processed_quarkus-arc-3.33.2.jar"));
     ApplicationModel model = modelWith(dep("io.quarkus", "quarkus-arc", "3.33.2", false));
 
     FastJarAssembler.assembleLibDirectories(
@@ -105,8 +110,81 @@ class FastJarAssemblerTest {
 
     assertFalse(
         Files.exists(libMain.resolve("processed_quarkus-arc-3.33.2.jar")),
-        "stale processed_ jar from augmentation must be removed");
+        "stale processed_ jar from augmentation must be renamed");
     assertTrue(Files.exists(libMain.resolve("io.quarkus.quarkus-arc-3.33.2.jar")));
+  }
+
+  @Test
+  void assembleLibDirectories_preservesAugmentedJarContent() throws IOException {
+    // Regression test: if augmentation removed an entry from a jar,
+    // assembleLibDirectories must NOT overwrite it with the pristine original.
+    Path outputDir = quarkusAppDir();
+    Path libMain = outputDir.resolve("quarkus-app/lib/main");
+    Files.createDirectories(libMain);
+
+    // Create a "pristine" runtime jar WITH a service file entry.
+    Path pristineJar =
+        createJarWithEntry(
+            "pristine/io/fabric8/kubernetes-httpclient-vertx/6.13.0",
+            "io.fabric8",
+            "kubernetes-httpclient-vertx",
+            "6.13.0",
+            "META-INF/services/io.fabric8.kubernetes.client.http.HttpClient$Factory",
+            "io.fabric8.kubernetes.client.vertx.VertxHttpClientFactory");
+
+    // Create an "augmented" jar (placed by Quarkus) WITHOUT the service file.
+    // This simulates RemovedResourceBuildItem having stripped the entry.
+    Path augmentedJar =
+        createJarAt(
+            "augmented/io/fabric8/kubernetes-httpclient-vertx/6.13.0",
+            "io.fabric8",
+            "kubernetes-httpclient-vertx",
+            "6.13.0");
+    Files.copy(augmentedJar, libMain.resolve("processed_kubernetes-httpclient-vertx-6.13.0.jar"));
+
+    ApplicationModel model =
+        modelWith(dep("io.fabric8", "kubernetes-httpclient-vertx", "6.13.0", false));
+
+    FastJarAssembler.assembleLibDirectories(outputDir, List.of(pristineJar), model);
+
+    // The assembled jar must come from augmentation (no service file), not the pristine original.
+    Path resultJar = libMain.resolve("io.fabric8.kubernetes-httpclient-vertx-6.13.0.jar");
+    assertTrue(Files.exists(resultJar), "jar should be present with Maven-convention name");
+    try (var jar = new JarFile(resultJar.toFile())) {
+      assertNull(
+          jar.getEntry("META-INF/services/io.fabric8.kubernetes.client.http.HttpClient$Factory"),
+          "removed service file must NOT be resurrected from the pristine classpath jar");
+    }
+  }
+
+  @Test
+  void assembleLibDirectories_reclassifiesBootToMainWithoutDeletion() throws IOException {
+    // Regression: a jar placed in lib/boot by augmentation but classified as main by the model
+    // must be moved to lib/main, not deleted by the dedupe check on the second directory pass.
+    Path outputDir = quarkusAppDir();
+    Path libBoot = outputDir.resolve("quarkus-app/lib/boot");
+    Path libMain = outputDir.resolve("quarkus-app/lib/main");
+    Files.createDirectories(libBoot);
+    Files.createDirectories(libMain);
+
+    // Augmentation placed this jar in boot, but the model says it belongs in main.
+    Path augmentedJar =
+        createJarAt("stage/io/quarkus/quarkus-arc/3.33.2", "io.quarkus", "quarkus-arc", "3.33.2");
+    Files.copy(augmentedJar, libBoot.resolve("processed_quarkus-arc-3.33.2.jar"));
+
+    ApplicationModel model = modelWith(dep("io.quarkus", "quarkus-arc", "3.33.2", false));
+
+    FastJarAssembler.assembleLibDirectories(
+        outputDir, List.of(createJar("io.quarkus", "quarkus-arc", "3.33.2")), model);
+
+    Path expectedTarget = libMain.resolve("io.quarkus.quarkus-arc-3.33.2.jar");
+    assertTrue(Files.exists(expectedTarget), "jar must be reclassified from boot to main");
+    assertFalse(
+        Files.exists(libBoot.resolve("processed_quarkus-arc-3.33.2.jar")),
+        "original boot location must be vacated");
+    assertFalse(
+        Files.exists(libBoot.resolve("io.quarkus.quarkus-arc-3.33.2.jar")),
+        "jar must not remain in boot under its new name");
   }
 
   // ---- assembleResourcesJar ----
@@ -224,6 +302,29 @@ class FastJarAssemblerTest {
     Path jar = dir.resolve(artifactId + "-" + version + ".jar");
     try (var jos = new JarOutputStream(new FileOutputStream(jar.toFile()))) {
       jos.putNextEntry(new JarEntry("META-INF/"));
+      jos.closeEntry();
+    }
+    return jar;
+  }
+
+  /** Creates a jar at a Maven-layout path with a specific entry and content. */
+  private Path createJarWithEntry(
+      String root,
+      String groupId,
+      String artifactId,
+      String version,
+      String entryName,
+      String entryContent)
+      throws IOException {
+    Path dir =
+        tempDir.resolve(root + "/" + groupId.replace('.', '/') + "/" + artifactId + "/" + version);
+    Files.createDirectories(dir);
+    Path jar = dir.resolve(artifactId + "-" + version + ".jar");
+    try (var jos = new JarOutputStream(new FileOutputStream(jar.toFile()))) {
+      jos.putNextEntry(new JarEntry("META-INF/"));
+      jos.closeEntry();
+      jos.putNextEntry(new JarEntry(entryName));
+      jos.write(entryContent.getBytes(java.nio.charset.StandardCharsets.UTF_8));
       jos.closeEntry();
     }
     return jar;


### PR DESCRIPTION
- Closes: #130 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved packaging of augmented JAR files using standard Maven filenames.
  * Preserved augmentation changes without overwriting them with original runtime files.
  * Corrected JAR placement between boot and main library directories.
  * Prevented excluded or duplicate artifacts from being packaged incorrectly.
  * Ensured removed service entries are not unintentionally restored during assembly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->