### PR TITLE
feat: add picocli subcommands and delete standalone enricher

### DIFF
--- a/docs/dev-mode.md
+++ b/docs/dev-mode.md
@@ -24,15 +24,17 @@ Unlike production augmentation (which runs in-process), dev mode uses a **separa
 ```mermaid
 sequenceDiagram
     participant Script as dev_launcher.sh
-    participant QC as QuarkifierConfig
+    participant CLI as QuarkifierCommand
+    participant AC as AugmentationCommand
     participant AE as AugmentationExecutor
     participant DML as DevModeLauncher
     participant Child as Child JVM Process
     participant DMM as DevModeMain
     participant IDM as IsolatedDevModeMain
 
-    Script->>QC: java -jar quarkifier_<minor>_deploy.jar --mode dev ...
-    QC->>AE: execute(config)
+    Script->>CLI: java -jar quarkifier_<minor>_deploy.jar augmentation --mode dev ...
+    CLI->>AC: dispatch subcommand
+    AC->>AE: execute(config)
     AE->>AE: buildApplicationModel(...)
     AE->>DML: launch(config, appModel)
     DML->>DML: buildDevModeContext(config)

--- a/docs/quarkifier.md
+++ b/docs/quarkifier.md
@@ -7,8 +7,17 @@ The Quarkifier (`com.clementguillot.quarkifier`) is a standalone Java tool that 
 
 ## CLI Interface
 
+The top-level command dispatches to `augmentation` and `enrich-extension`:
+
+```
+java -jar quarkifier_<minor>_deploy.jar [--help] [--version] <command>
+```
+
+### Augmentation
+
 ```
 java -jar quarkifier_<minor>_deploy.jar \
+  augmentation \
   --application-classpath <jar:jar:...> \
   --deployment-classpath <jar:jar:...> \
   [--application-classpath-file <path>] \
@@ -37,7 +46,7 @@ java -jar quarkifier_<minor>_deploy.jar \
   [-V|--version]
 ```
 
-### Flags
+#### Flags
 
 | Flag | Required | Default | Description |
 |---|---|---|---|
@@ -70,12 +79,28 @@ java -jar quarkifier_<minor>_deploy.jar \
 
 *Either the inline flag or the `-file` variant must be provided. The `-file` variants read the classpath from a file (one line, colon-separated paths) to avoid "Argument list too long" errors on Linux when the classpath is very long. When both inline and file are provided, the file variant takes precedence regardless of argument order.
 
+### Extension enrichment
+
+```
+java -jar quarkifier_<minor>_deploy.jar \
+  enrich-extension \
+  <runtime.jar> \
+  <output.yaml> \
+  <quarkus-version> \
+  <classpath-file> \
+  <extension-name>
+```
+
+This command reads `META-INF/quarkus-extension.yaml` from the runtime jar, adds
+the Quarkus core version and extension dependencies discovered from the compile
+classpath, then writes the enriched YAML to the requested output path.
+
 ### Exit Codes
 
 | Code | Meaning |
 |---|---|
 | 0 | Success (warnings may have been emitted to stderr) |
-| 1 | Augmentation failure (stack trace on stderr) |
+| 1 | Command execution failure |
 | 2 | Invalid CLI arguments (usage message on stderr) |
 
 ## Package Structure
@@ -83,7 +108,9 @@ java -jar quarkifier_<minor>_deploy.jar \
 ```
 com.clementguillot.quarkifier
 ├── QuarkifierLauncher              Entry point (thin shell, delegates to picocli)
-├── QuarkifierCommand               Picocli @Command: CLI parsing, validation, pipeline execution
+├── QuarkifierCommand               Top-level picocli command dispatcher
+├── AugmentationCommand             Parses augmentation options and executes the pipeline
+├── EnrichExtensionCommand          Parses extension-enrichment arguments
 ├── QuarkifierConfig                Immutable record for config + toArgs() serialization
 ├── QuarkifierVersionProvider       Picocli IVersionProvider: reads version from classpath resource
 ├── AugmentationMode                Enum: NORMAL, TEST, DEV, NATIVE
@@ -93,6 +120,7 @@ com.clementguillot.quarkifier
 ├── extension/                      Extension discovery and validation
 │   ├── ExtensionInfo               Record: groupId, artifactId, version, sourceJar
 │   ├── ExtensionScanner            Scans jars for quarkus-extension.properties
+│   ├── ExtensionYamlEnricher       Enriches quarkus-extension.yaml build metadata
 │   ├── DeploymentArtifactResolver  Maps extensions to their -deployment jars
 │   ├── MissingDeploymentArtifactException
 │   └── VersionChecker              Compares extension versions against expected
@@ -119,7 +147,8 @@ com.clementguillot.quarkifier
 
 ## QuarkifierConfig Record
 
-All CLI arguments are parsed by picocli into `QuarkifierCommand` fields, then forwarded to an immutable `QuarkifierConfig` record:
+Augmentation arguments are parsed by picocli into `AugmentationCommand` fields,
+then forwarded to an immutable `QuarkifierConfig` record:
 
 ```java
 public record QuarkifierConfig(
@@ -182,7 +211,11 @@ graph LR
 
 ### Step 1: CLI Parsing
 
-`QuarkifierCommand` (picocli `@Command`) parses and validates arguments, resolves `--*-file` fallbacks, and builds an immutable `QuarkifierConfig`. Picocli exits with code 2 on invalid input. The convenience method `QuarkifierConfig.parse()` delegates to this for programmatic use.
+`QuarkifierCommand` dispatches to `AugmentationCommand`, which parses and
+validates augmentation arguments, resolves `--*-file` fallbacks, and builds an
+immutable `QuarkifierConfig`. Picocli exits with code 2 on invalid input. The
+convenience method `QuarkifierConfig.parse()` delegates to the augmentation
+subcommand for programmatic use.
 
 ### Step 2: Extension Scanning
 

--- a/quarkifier/src/main/java/com/clementguillot/quarkifier/AugmentationCommand.java
+++ b/quarkifier/src/main/java/com/clementguillot/quarkifier/AugmentationCommand.java
@@ -1,0 +1,295 @@
+package com.clementguillot.quarkifier;
+
+import com.clementguillot.quarkifier.augmentation.AugmentationExecutor;
+import com.clementguillot.quarkifier.extension.ExtensionScanner;
+import com.clementguillot.quarkifier.extension.VersionChecker;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+import org.jboss.logging.Logger;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Spec;
+
+/**
+ * Subcommand that performs Quarkus build-time augmentation.
+ *
+ * <p>Exit codes: 0 = success, 1 = augmentation failure, 2 = invalid arguments (picocli).
+ */
+@Command(
+    name = "augmentation",
+    description = "Run Quarkus build-time augmentation to produce a Fast_Jar.",
+    mixinStandardHelpOptions = true)
+@SuppressWarnings({"PMD.TooManyFields", "PMD.TooManyMethods"})
+// picocli pattern — one field per CLI option; not worth splitting
+public final class AugmentationCommand implements Callable<Integer> {
+
+  @Spec private CommandSpec commandSpec;
+
+  // ---- Classpath options (colon-separated, with file fallback) ----
+
+  @Option(
+      names = "--application-classpath",
+      description = "Colon-separated list of runtime jars.",
+      split = ":",
+      defaultValue = "")
+  private List<Path> applicationClasspath;
+
+  @Option(
+      names = "--application-classpath-file",
+      description =
+          "File containing the application classpath (alternative to --application-classpath).")
+  private Path applicationClasspathFile;
+
+  @Option(
+      names = "--deployment-classpath",
+      description = "Colon-separated list of deployment jars.",
+      split = ":",
+      defaultValue = "")
+  private List<Path> deploymentClasspath;
+
+  @Option(
+      names = "--deployment-classpath-file",
+      description =
+          "File containing the deployment classpath (alternative to --deployment-classpath).")
+  private Path deploymentClasspathFile;
+
+  @Option(
+      names = "--core-deployment-classpath",
+      description = "Colon-separated list of core deployment jars (dev mode only).",
+      split = ":",
+      defaultValue = "")
+  private List<Path> coreDeploymentClasspath;
+
+  @Option(
+      names = "--core-deployment-classpath-file",
+      description =
+          "File containing the core deployment classpath (alternative to"
+              + " --core-deployment-classpath).")
+  private Path coreDeploymentClasspathFile;
+
+  @Option(
+      names = "--local-app-jars",
+      description = "Colon-separated local workspace jars to use as application roots.",
+      split = ":",
+      defaultValue = "")
+  private List<Path> localAppJars;
+
+  @Option(
+      names = "--local-app-jars-file",
+      description = "File containing local app jars (alternative to --local-app-jars).")
+  private Path localAppJarsFile;
+
+  // ---- Output ----
+
+  @Option(
+      names = "--output-dir",
+      required = true,
+      description = "Directory where Fast_Jar output is written.")
+  private Path outputDir;
+
+  // ---- Optional flags (comma-separated lists) ----
+
+  @Option(names = "--resources", description = "Comma-separated resource file paths.", split = ",")
+  private List<Path> resources;
+
+  @Option(
+      names = "--mode",
+      description = "Augmentation mode: normal, test, dev, or native.",
+      defaultValue = "normal")
+  private String mode;
+
+  @Option(
+      names = "--expected-quarkus-version",
+      description = "Expected Quarkus version for mismatch warnings.")
+  private String expectedQuarkusVersion;
+
+  @Option(names = "--app-name", description = "Application name for Quarkus startup banner.")
+  private String appName;
+
+  @Option(names = "--app-version", description = "Application version for Quarkus startup banner.")
+  private String appVersion;
+
+  @Option(
+      names = "--main-class",
+      description = "Fully-qualified custom main class annotated with @QuarkusMain.")
+  private String mainClass;
+
+  @Option(
+      names = "--native-builder-image",
+      description = "Native builder image for platform.quarkus.native.builder-image.")
+  private String nativeBuilderImage;
+
+  // ---- Dev-mode options ----
+
+  @Option(
+      names = "--source-dirs",
+      description = "Comma-separated source directories for hot-reload in dev mode.",
+      split = ",")
+  private List<Path> sourceDirs;
+
+  @Option(names = "--classes-dir", description = "Mutable directory for .class files in dev mode.")
+  private Path classesDir;
+
+  @Option(
+      names = "--bazel-targets",
+      description = "Comma-separated Bazel targets to rebuild on source changes.",
+      split = ",")
+  private List<String> bazelTargets;
+
+  @Option(
+      names = "--classes-output-dirs",
+      description = "Comma-separated bazel-bin output directories containing .class files.",
+      split = ",")
+  private List<Path> classesOutputDirs;
+
+  @Option(
+      names = "--workspace-dir",
+      description = "Bazel workspace root directory for running bazel build.")
+  private Path workspaceDir;
+
+  @Option(
+      names = "--bazel-build-timeout-seconds",
+      description = "Timeout in seconds for bazel build process.",
+      defaultValue = "600")
+  private long bazelBuildTimeoutSeconds;
+
+  @Option(
+      names = "--bazel-command",
+      description = "Bazel binary to invoke for hot-reload builds.",
+      defaultValue = "bazel")
+  private String bazelCommand;
+
+  @Option(
+      names = "--bazel-build-args",
+      description = "Comma-separated extra flags for the hot-reload bazel build.",
+      split = ",")
+  private List<String> bazelBuildArgs;
+
+  // ---- Execution ----
+
+  @Override
+  public Integer call() {
+    QuarkifierConfig config = toConfig();
+    try {
+      var extensions = ExtensionScanner.scan(config.applicationClasspath());
+      VersionChecker.check(extensions, config.expectedQuarkusVersion());
+      AugmentationExecutor.execute(config);
+    } catch (AugmentationException e) {
+      logger().error("Augmentation failed", e);
+      return 1;
+    } catch (IOException e) {
+      logger().errorf("Error scanning extensions: %s", e.getMessage());
+      return 1;
+    }
+    return 0;
+  }
+
+  /**
+   * Builds an immutable {@link QuarkifierConfig} from the parsed picocli options.
+   *
+   * @throws CommandLine.ParameterException on invalid values
+   */
+  public QuarkifierConfig toConfig() {
+    List<Path> resolvedAppCp = resolveClasspath(applicationClasspath, applicationClasspathFile);
+    List<Path> resolvedDeployCp = resolveClasspath(deploymentClasspath, deploymentClasspathFile);
+    List<Path> resolvedCoreCp =
+        resolveClasspath(coreDeploymentClasspath, coreDeploymentClasspathFile);
+    List<Path> resolvedLocalJars = resolveClasspath(localAppJars, localAppJarsFile);
+
+    if (resolvedAppCp.isEmpty()) {
+      throw parameterException(
+          "Either --application-classpath or --application-classpath-file must be provided");
+    }
+    if (resolvedDeployCp.isEmpty()) {
+      throw parameterException(
+          "Either --deployment-classpath or --deployment-classpath-file must be provided");
+    }
+    validateNonEmpty(mainClass, "--main-class");
+    validateNonEmpty(nativeBuilderImage, "--native-builder-image");
+    validateNonEmpty(bazelCommand, "--bazel-command");
+    if (outputDir.toString().isEmpty()) {
+      throw parameterException("Value for --output-dir must not be empty");
+    }
+    if (bazelBuildTimeoutSeconds <= 0) {
+      throw parameterException("--bazel-build-timeout-seconds must be positive");
+    }
+
+    return new QuarkifierConfig(
+        resolvedAppCp,
+        resolvedDeployCp,
+        resolvedCoreCp,
+        outputDir,
+        orEmpty(resources),
+        parseMode(mode),
+        expectedQuarkusVersion,
+        appName,
+        appVersion,
+        mainClass,
+        nativeBuilderImage,
+        orEmpty(sourceDirs),
+        classesDir,
+        orEmpty(bazelTargets),
+        orEmpty(classesOutputDirs),
+        workspaceDir,
+        bazelBuildTimeoutSeconds,
+        bazelCommand,
+        orEmpty(bazelBuildArgs),
+        resolvedLocalJars);
+  }
+
+  // ---- internal helpers ----
+
+  private List<Path> resolveClasspath(List<Path> inline, Path file) {
+    if (file != null) {
+      try {
+        String content = Files.readString(file).strip();
+        if (content.isEmpty()) {
+          return List.of();
+        }
+        return Arrays.stream(content.split(":")).filter(s -> !s.isEmpty()).map(Path::of).toList();
+      } catch (IOException e) {
+        throw parameterException("Failed to read classpath file: " + file, e);
+      }
+    }
+    return inline.stream().filter(p -> !p.toString().isEmpty()).toList();
+  }
+
+  private static <T> List<T> orEmpty(List<T> list) {
+    if (list == null) {
+      return List.of();
+    }
+    return list.stream().filter(e -> !e.toString().isBlank()).toList();
+  }
+
+  private CommandLine.ParameterException parameterException(String message) {
+    return new CommandLine.ParameterException(commandSpec.commandLine(), message);
+  }
+
+  private CommandLine.ParameterException parameterException(String message, Throwable cause) {
+    return new CommandLine.ParameterException(commandSpec.commandLine(), message, cause);
+  }
+
+  private static Logger logger() {
+    return Logger.getLogger(AugmentationCommand.class);
+  }
+
+  private void validateNonEmpty(String value, String name) {
+    if (value != null && value.isBlank()) {
+      throw parameterException("Value for " + name + " must not be empty");
+    }
+  }
+
+  private AugmentationMode parseMode(String modeStr) {
+    try {
+      return AugmentationMode.parse(modeStr);
+    } catch (IllegalArgumentException e) {
+      throw parameterException(e.getMessage(), e);
+    }
+  }
+}

--- a/quarkifier/src/main/java/com/clementguillot/quarkifier/EnrichExtensionCommand.java
+++ b/quarkifier/src/main/java/com/clementguillot/quarkifier/EnrichExtensionCommand.java
@@ -1,0 +1,41 @@
+package com.clementguillot.quarkifier;
+
+import com.clementguillot.quarkifier.extension.ExtensionYamlEnricher;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+/**
+ * Subcommand that enriches a {@code quarkus-extension.yaml} with build metadata.
+ *
+ * <p>Delegates to {@link ExtensionYamlEnricher} for the actual processing.
+ */
+@Command(
+    name = "enrich-extension",
+    description = "Enrich a quarkus-extension.yaml with build metadata.",
+    mixinStandardHelpOptions = true)
+public final class EnrichExtensionCommand implements Callable<Integer> {
+
+  @Parameters(index = "0", description = "Runtime jar containing the base extension yaml.")
+  private Path runtimeJar;
+
+  @Parameters(index = "1", description = "Output path for the enriched yaml file.")
+  private Path output;
+
+  @Parameters(index = "2", description = "Quarkus core version (e.g. 3.33.2).")
+  private String quarkusVersion;
+
+  @Parameters(index = "3", description = "File listing the compile classpath (one jar per line).")
+  private Path classpathFile;
+
+  @Parameters(index = "4", description = "Extension display name.")
+  private String extensionName;
+
+  @Override
+  public Integer call() throws IOException {
+    ExtensionYamlEnricher.enrich(runtimeJar, output, quarkusVersion, classpathFile, extensionName);
+    return 0;
+  }
+}

--- a/quarkifier/src/main/java/com/clementguillot/quarkifier/QuarkifierCommand.java
+++ b/quarkifier/src/main/java/com/clementguillot/quarkifier/QuarkifierCommand.java
@@ -1,184 +1,27 @@
 package com.clementguillot.quarkifier;
 
-import com.clementguillot.quarkifier.augmentation.AugmentationExecutor;
-import com.clementguillot.quarkifier.extension.ExtensionScanner;
-import com.clementguillot.quarkifier.extension.VersionChecker;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
-import java.util.concurrent.Callable;
-import org.jboss.logging.Logger;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Model.CommandSpec;
-import picocli.CommandLine.Option;
-import picocli.CommandLine.Spec;
 
 /**
- * Picocli command that parses CLI arguments and builds a {@link QuarkifierConfig}.
+ * Top-level picocli command that dispatches to subcommands.
  *
- * <p>The {@link #call()} method returns an exit code: 0 on success, 1 on augmentation failure.
- * Picocli handles exit code 2 (usage errors) automatically.
+ * <p>Running without a subcommand prints usage help. Available subcommands:
+ *
+ * <ul>
+ *   <li>{@code augmentation} — run Quarkus build-time augmentation
+ *   <li>{@code enrich-extension} — enrich a quarkus-extension.yaml with build metadata
+ * </ul>
  */
 @Command(
     name = "quarkifier",
     mixinStandardHelpOptions = true,
     versionProvider = QuarkifierVersionProvider.class,
-    description = "Invokes Quarkus build-time augmentation to produce a Fast_Jar.",
-    exitCodeListHeading = "Exit Codes:%n",
-    exitCodeList = {
-      " 0:Success",
-      " 1:Augmentation failure",
-      " 2:Invalid CLI arguments",
-    })
-@SuppressWarnings({"PMD.TooManyFields", "PMD.TooManyMethods"})
-// picocli pattern — one field per CLI option, one helper per concern; not worth splitting
-public final class QuarkifierCommand implements Callable<Integer> {
+    description = "Quarkus build tooling for Bazel.",
+    subcommands = {AugmentationCommand.class, EnrichExtensionCommand.class})
+public final class QuarkifierCommand implements Runnable {
 
-  @Spec private CommandSpec commandSpec;
-
-  // ---- Classpath options (colon-separated, with file fallback) ----
-
-  @Option(
-      names = "--application-classpath",
-      description = "Colon-separated list of runtime jars.",
-      split = ":",
-      defaultValue = "")
-  private List<Path> applicationClasspath;
-
-  @Option(
-      names = "--application-classpath-file",
-      description =
-          "File containing the application classpath (alternative to --application-classpath).")
-  private Path applicationClasspathFile;
-
-  @Option(
-      names = "--deployment-classpath",
-      description = "Colon-separated list of deployment jars.",
-      split = ":",
-      defaultValue = "")
-  private List<Path> deploymentClasspath;
-
-  @Option(
-      names = "--deployment-classpath-file",
-      description =
-          "File containing the deployment classpath (alternative to --deployment-classpath).")
-  private Path deploymentClasspathFile;
-
-  @Option(
-      names = "--core-deployment-classpath",
-      description = "Colon-separated list of core deployment jars (dev mode only).",
-      split = ":",
-      defaultValue = "")
-  private List<Path> coreDeploymentClasspath;
-
-  @Option(
-      names = "--core-deployment-classpath-file",
-      description =
-          "File containing the core deployment classpath (alternative to"
-              + " --core-deployment-classpath).")
-  private Path coreDeploymentClasspathFile;
-
-  @Option(
-      names = "--local-app-jars",
-      description = "Colon-separated local workspace jars to use as application roots.",
-      split = ":",
-      defaultValue = "")
-  private List<Path> localAppJars;
-
-  @Option(
-      names = "--local-app-jars-file",
-      description = "File containing local app jars (alternative to --local-app-jars).")
-  private Path localAppJarsFile;
-
-  // ---- Output ----
-
-  @Option(
-      names = "--output-dir",
-      required = true,
-      description = "Directory where Fast_Jar output is written.")
-  private Path outputDir;
-
-  // ---- Optional flags (comma-separated lists) ----
-
-  @Option(names = "--resources", description = "Comma-separated resource file paths.", split = ",")
-  private List<Path> resources;
-
-  @Option(
-      names = "--mode",
-      description = "Augmentation mode: normal, test, dev, or native.",
-      defaultValue = "normal")
-  private String mode;
-
-  @Option(
-      names = "--expected-quarkus-version",
-      description = "Expected Quarkus version for mismatch warnings.")
-  private String expectedQuarkusVersion;
-
-  @Option(names = "--app-name", description = "Application name for Quarkus startup banner.")
-  private String appName;
-
-  @Option(names = "--app-version", description = "Application version for Quarkus startup banner.")
-  private String appVersion;
-
-  @Option(
-      names = "--main-class",
-      description = "Fully-qualified custom main class annotated with @QuarkusMain.")
-  private String mainClass;
-
-  @Option(
-      names = "--native-builder-image",
-      description = "Native builder image for platform.quarkus.native.builder-image.")
-  private String nativeBuilderImage;
-
-  // ---- Dev-mode options ----
-
-  @Option(
-      names = "--source-dirs",
-      description = "Comma-separated source directories for hot-reload in dev mode.",
-      split = ",")
-  private List<Path> sourceDirs;
-
-  @Option(names = "--classes-dir", description = "Mutable directory for .class files in dev mode.")
-  private Path classesDir;
-
-  @Option(
-      names = "--bazel-targets",
-      description = "Comma-separated Bazel targets to rebuild on source changes.",
-      split = ",")
-  private List<String> bazelTargets;
-
-  @Option(
-      names = "--classes-output-dirs",
-      description = "Comma-separated bazel-bin output directories containing .class files.",
-      split = ",")
-  private List<Path> classesOutputDirs;
-
-  @Option(
-      names = "--workspace-dir",
-      description = "Bazel workspace root directory for running bazel build.")
-  private Path workspaceDir;
-
-  @Option(
-      names = "--bazel-build-timeout-seconds",
-      description = "Timeout in seconds for bazel build process.",
-      defaultValue = "600")
-  private long bazelBuildTimeoutSeconds;
-
-  @Option(
-      names = "--bazel-command",
-      description = "Bazel binary to invoke for hot-reload builds.",
-      defaultValue = "bazel")
-  private String bazelCommand;
-
-  @Option(
-      names = "--bazel-build-args",
-      description = "Comma-separated extra flags for the hot-reload bazel build.",
-      split = ",")
-  private List<String> bazelBuildArgs;
-
-  // ---- Factory ----
+  @CommandLine.Spec private CommandLine.Model.CommandSpec spec;
 
   /** Creates a {@link CommandLine} configured for quarkifier conventions. */
   public static CommandLine createCommandLine() {
@@ -187,144 +30,9 @@ public final class QuarkifierCommand implements Callable<Integer> {
     return commandLine;
   }
 
-  // ---- Execution ----
-
+  /** Prints usage when invoked without a subcommand. */
   @Override
-  public Integer call() {
-    QuarkifierConfig config = toConfig();
-    try {
-      run(config);
-    } catch (AugmentationException e) {
-      logger().error("Augmentation failed", e);
-      return 1;
-    } catch (IOException e) {
-      logger().errorf("Error scanning extensions: %s", e.getMessage());
-      return 1;
-    }
-    return 0;
-  }
-
-  /**
-   * Executes the augmentation pipeline with the given config.
-   *
-   * @throws AugmentationException on augmentation failure
-   * @throws IOException on extension scanning failure
-   */
-  static void run(QuarkifierConfig config) throws AugmentationException, IOException {
-    var extensions = ExtensionScanner.scan(config.applicationClasspath());
-    VersionChecker.check(extensions, config.expectedQuarkusVersion());
-    AugmentationExecutor.execute(config);
-  }
-
-  /**
-   * Builds an immutable {@link QuarkifierConfig} from the parsed picocli options.
-   *
-   * @throws CommandLine.ParameterException on invalid values
-   */
-  public QuarkifierConfig toConfig() {
-    // Resolve --*-file fallbacks (file wins over inline)
-    List<Path> resolvedAppCp = resolveClasspath(applicationClasspath, applicationClasspathFile);
-    List<Path> resolvedDeployCp = resolveClasspath(deploymentClasspath, deploymentClasspathFile);
-    List<Path> resolvedCoreCp =
-        resolveClasspath(coreDeploymentClasspath, coreDeploymentClasspathFile);
-    List<Path> resolvedLocalJars = resolveClasspath(localAppJars, localAppJarsFile);
-
-    // Validate
-    if (resolvedAppCp.isEmpty()) {
-      throw parameterException(
-          "Either --application-classpath or --application-classpath-file must be provided");
-    }
-    if (resolvedDeployCp.isEmpty()) {
-      throw parameterException(
-          "Either --deployment-classpath or --deployment-classpath-file must be provided");
-    }
-    validateNonEmpty(mainClass, "--main-class");
-    validateNonEmpty(nativeBuilderImage, "--native-builder-image");
-    validateNonEmpty(bazelCommand, "--bazel-command");
-    if (outputDir.toString().isEmpty()) {
-      throw parameterException("Value for --output-dir must not be empty");
-    }
-    if (bazelBuildTimeoutSeconds <= 0) {
-      throw parameterException("--bazel-build-timeout-seconds must be positive");
-    }
-
-    // Build config — fields already typed by picocli
-    return new QuarkifierConfig(
-        resolvedAppCp,
-        resolvedDeployCp,
-        resolvedCoreCp,
-        outputDir,
-        orEmpty(resources),
-        parseMode(mode),
-        expectedQuarkusVersion,
-        appName,
-        appVersion,
-        mainClass,
-        nativeBuilderImage,
-        orEmpty(sourceDirs),
-        classesDir,
-        orEmpty(bazelTargets),
-        orEmpty(classesOutputDirs),
-        workspaceDir,
-        bazelBuildTimeoutSeconds,
-        bazelCommand,
-        orEmpty(bazelBuildArgs),
-        resolvedLocalJars);
-  }
-
-  // ---- internal helpers ----
-
-  /**
-   * Resolves a classpath: if a file is provided, reads and splits it (colon-separated); otherwise
-   * returns the inline list as parsed by picocli. Filters out empty-string entries that picocli
-   * produces from defaultValue="".
-   */
-  private List<Path> resolveClasspath(List<Path> inline, Path file) {
-    if (file != null) {
-      try {
-        String content = Files.readString(file).strip();
-        if (content.isEmpty()) {
-          return List.of();
-        }
-        return List.of(content.split(":")).stream().map(Path::of).toList();
-      } catch (IOException e) {
-        throw parameterException("Failed to read classpath file: " + file, e);
-      }
-    }
-    // picocli splits defaultValue="" into a single-element list with Path("") — filter it out
-    return inline.stream().filter(p -> !p.toString().isEmpty()).toList();
-  }
-
-  private static <T> List<T> orEmpty(List<T> list) {
-    if (list == null) {
-      return List.of();
-    }
-    return list.stream().filter(e -> !e.toString().isBlank()).toList();
-  }
-
-  private CommandLine.ParameterException parameterException(String message) {
-    return new CommandLine.ParameterException(commandSpec.commandLine(), message);
-  }
-
-  private CommandLine.ParameterException parameterException(String message, Throwable cause) {
-    return new CommandLine.ParameterException(commandSpec.commandLine(), message, cause);
-  }
-
-  private static Logger logger() {
-    return Logger.getLogger(QuarkifierCommand.class);
-  }
-
-  private void validateNonEmpty(String value, String name) {
-    if (value != null && value.isBlank()) {
-      throw parameterException("Value for " + name + " must not be empty");
-    }
-  }
-
-  private AugmentationMode parseMode(String modeStr) {
-    try {
-      return AugmentationMode.parse(modeStr);
-    } catch (IllegalArgumentException e) {
-      throw parameterException(e.getMessage(), e);
-    }
+  public void run() {
+    spec.commandLine().usage(spec.commandLine().getOut());
   }
 }

--- a/quarkifier/src/main/java/com/clementguillot/quarkifier/QuarkifierConfig.java
+++ b/quarkifier/src/main/java/com/clementguillot/quarkifier/QuarkifierConfig.java
@@ -59,13 +59,19 @@ public record QuarkifierConfig(
    * Parses CLI arguments into a {@link QuarkifierConfig} via picocli.
    *
    * <p>Convenience factory used by tests and internal callers that already have an args array.
+   * Automatically prepends the {@code augmentation} subcommand.
    *
-   * @throws IllegalStateException wrapping any picocli parse/validation error
+   * @throws picocli.CommandLine.ParameterException on parse/validation error
    */
   public static QuarkifierConfig parse(String... args) {
     var commandLine = QuarkifierCommand.createCommandLine();
-    commandLine.parseArgs(args);
-    return ((QuarkifierCommand) commandLine.getCommand()).toConfig();
+    // Prepend "augmentation" subcommand for callers that pass raw option args
+    String[] fullArgs = new String[args.length + 1];
+    fullArgs[0] = "augmentation";
+    System.arraycopy(args, 0, fullArgs, 1, args.length);
+    commandLine.parseArgs(fullArgs);
+    var augCmd = commandLine.getSubcommands().get("augmentation").getCommand();
+    return ((AugmentationCommand) augCmd).toConfig();
   }
 
   /** Serializes this config back to a CLI argument array, suitable for round-trip testing. */

--- a/quarkifier/src/main/java/com/clementguillot/quarkifier/QuarkifierLauncher.java
+++ b/quarkifier/src/main/java/com/clementguillot/quarkifier/QuarkifierLauncher.java
@@ -8,9 +8,13 @@ package com.clementguillot.quarkifier;
  */
 public final class QuarkifierLauncher {
 
+  private static final String JUL_MANAGER_PROPERTY = "java.util.logging.manager";
+  private static final String JBOSS_LOG_MANAGER = "org.jboss.logmanager.LogManager";
+
   private QuarkifierLauncher() {}
 
   public static void main(String... args) {
+    System.setProperty(JUL_MANAGER_PROPERTY, JBOSS_LOG_MANAGER);
     int exitCode = QuarkifierCommand.createCommandLine().execute(args);
     System.exit(exitCode);
   }

--- a/quarkifier/src/main/java/com/clementguillot/quarkifier/extension/ExtensionYamlEnricher.java
+++ b/quarkifier/src/main/java/com/clementguillot/quarkifier/extension/ExtensionYamlEnricher.java
@@ -1,6 +1,5 @@
-package com.clementguillot.rules_quarkus;
+package com.clementguillot.quarkifier.extension;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -10,74 +9,77 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 import java.util.TreeSet;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
 /**
- * Hermetic replacement for the shell-based quarkus-extension.yaml enrichment.
+ * Enriches a {@code quarkus-extension.yaml} with build metadata.
  *
- * <p>Reproduces what the Maven/Gradle Quarkus extension plugin appends: the Quarkus core version
- * and the extension-dependencies list (other Quarkus extensions on the compile classpath,
- * discovered via their embedded pom.properties).
- *
- * <p>Usage: EnrichExtensionYaml &lt;runtime.jar&gt; &lt;output.yaml&gt; &lt;quarkusVersion&gt;
- * &lt;classpath.params&gt; &lt;extensionName&gt;
+ * <p>Appends the Quarkus core version and extension-dependency list (other Quarkus extensions on
+ * the compile classpath, discovered via their embedded {@code pom.properties}).
  */
-public final class EnrichExtensionYaml {
+@SuppressWarnings("PMD.GodClass") // single-purpose utility; cohesion is high despite metric
+public final class ExtensionYamlEnricher {
 
-  public static void main(String[] args) throws IOException {
-    if (args.length != 5) {
-      System.err.println(
-          "Usage: EnrichExtensionYaml <runtime.jar> <output.yaml>"
-              + " <quarkusVersion> <classpath.params> <extensionName>");
-      System.exit(1);
-    }
+  private ExtensionYamlEnricher() {}
 
-    Path runtimeJar = Path.of(args[0]);
-    Path output = Path.of(args[1]);
-    String quarkusVersion = args[2];
-    Path classpathFile = Path.of(args[3]);
-    String extensionName = args[4];
-
-    // Discover extension dependencies from the compile classpath.
-    TreeSet<String> deps = new TreeSet<>();
-    try (BufferedReader reader = Files.newBufferedReader(classpathFile)) {
-      String line;
-      while ((line = reader.readLine()) != null) {
-        line = line.trim();
-        if (line.isEmpty()) {
-          continue;
-        }
-        Path jar = Path.of(line);
-        if (!Files.isRegularFile(jar)) {
-          continue;
-        }
-        if (!hasEntry(jar, "META-INF/quarkus-extension.properties")) {
-          continue;
-        }
-        String coords = extractPomCoordinates(jar);
-        if (coords != null) {
-          deps.add(coords);
-        }
-      }
-    }
-
+  /**
+   * Enriches the extension yaml from the given runtime jar and writes the result to output.
+   *
+   * @param runtimeJar jar containing the base {@code META-INF/quarkus-extension.yaml}
+   * @param output path where the enriched yaml is written
+   * @param quarkusVersion Quarkus core version string
+   * @param classpathFile file listing the compile classpath (one jar per line)
+   * @param extensionName extension display name (used as fallback if no yaml exists)
+   */
+  public static void enrich(
+      Path runtimeJar, Path output, String quarkusVersion, Path classpathFile, String extensionName)
+      throws IOException {
+    Set<String> deps = discoverExtensionDependencies(classpathFile);
     String baseYaml = extractEntryText(runtimeJar, "META-INF/quarkus-extension.yaml");
-    Files.writeString(
-        output,
-        enrichMetadata(baseYaml, extensionName, quarkusVersion, List.copyOf(deps)),
-        StandardCharsets.UTF_8);
+    String enriched = enrichMetadata(baseYaml, extensionName, quarkusVersion, List.copyOf(deps));
+    Files.writeString(output, enriched, StandardCharsets.UTF_8);
   }
 
-  private static String enrichMetadata(
-      String baseYaml, String extensionName, String quarkusVersion, List<String> deps)
-      throws IOException {
-    if (baseYaml == null || baseYaml.isBlank()) {
-      baseYaml = "name: \"" + quoteYaml(extensionName) + "\"\nmetadata:\n";
-    }
+  // ---- extension dependency discovery ----
 
-    String normalized = baseYaml.replace("\r\n", "\n").replace('\r', '\n');
+  /**
+   * Scans jars on the classpath file for Quarkus extensions and returns their coordinates.
+   *
+   * @return sorted set of "groupId:artifactId" strings
+   */
+  static Set<String> discoverExtensionDependencies(Path cpFile) throws IOException {
+    Set<String> deps = new TreeSet<>();
+    for (String entry : Files.readAllLines(cpFile)) {
+      String trimmed = entry.trim();
+      if (trimmed.isEmpty()) {
+        continue;
+      }
+      Path jar = Path.of(trimmed);
+      if (!Files.isRegularFile(jar) || !hasEntry(jar, "META-INF/quarkus-extension.properties")) {
+        continue;
+      }
+      String coords = extractPomCoordinates(jar);
+      if (coords != null) {
+        deps.add(coords);
+      }
+    }
+    return deps;
+  }
+
+  // ---- yaml enrichment ----
+
+  @SuppressWarnings("PMD.CognitiveComplexity")
+  static String enrichMetadata(String inputYaml, String extName, String qVersion, List<String> deps)
+      throws IOException {
+    String yaml =
+        (inputYaml == null || inputYaml.isBlank())
+            ? "name: \"" + quoteYaml(extName) + "\"\nmetadata:\n"
+            : inputYaml;
+
+    String normalized = yaml.replace("\r\n", "\n").replace('\r', '\n');
     List<String> lines = new ArrayList<>(List.of(normalized.split("\n", -1)));
     if (!lines.isEmpty() && lines.get(lines.size() - 1).isEmpty()) {
       lines.remove(lines.size() - 1);
@@ -99,7 +101,7 @@ public final class EnrichExtensionYaml {
     metadataEnd = findMetadataEnd(lines, metadataLine);
 
     List<String> generated = new ArrayList<>();
-    generated.add("  built-with-quarkus-core: \"" + quoteYaml(quarkusVersion) + "\"");
+    generated.add("  built-with-quarkus-core: \"" + quoteYaml(qVersion) + "\"");
     generated.add("  extension-dependencies:");
     for (String coord : deps) {
       generated.add("    - \"" + quoteYaml(coord) + "\"");
@@ -111,8 +113,7 @@ public final class EnrichExtensionYaml {
 
   private static int findTopLevelMetadataLine(List<String> lines) {
     for (int i = 0; i < lines.size(); i++) {
-      String line = lines.get(i);
-      if (line.startsWith("metadata:")) {
+      if (lines.get(i).startsWith("metadata:")) {
         return i;
       }
     }
@@ -132,37 +133,45 @@ public final class EnrichExtensionYaml {
     return lines.size();
   }
 
+  @SuppressWarnings("PMD.AvoidReassigningParameters")
   private static void stripGeneratedMetadata(List<String> lines, int start, int end) {
     for (int i = start; i < end; ) {
       String line = lines.get(i);
       if (line.startsWith("  built-with-quarkus-core:")) {
         lines.remove(i);
         end--;
-        continue;
-      }
-      if (line.startsWith("  extension-dependencies:")) {
+      } else if (line.startsWith("  extension-dependencies:")) {
+        int dependencyIndent = line.length() - line.stripLeading().length();
         lines.remove(i);
         end--;
-        while (i < end && isExtensionDependencyListLine(lines.get(i))) {
+        while (i < end) {
+          String nestedLine = lines.get(i);
+          String stripped = nestedLine.stripLeading();
+          int indent = nestedLine.length() - stripped.length();
+          boolean belongs =
+              nestedLine.isBlank()
+                  || (stripped.startsWith("#") && indent >= dependencyIndent)
+                  || indent > dependencyIndent
+                  || (indent == dependencyIndent && stripped.startsWith("-"));
+          if (!belongs) {
+            break;
+          }
           lines.remove(i);
           end--;
         }
-        continue;
+      } else {
+        i++;
       }
-      i++;
     }
-  }
-
-  private static boolean isExtensionDependencyListLine(String line) {
-    return line.startsWith("  - ") || line.startsWith("    - ") || line.isBlank();
   }
 
   private static String quoteYaml(String value) {
     return value.replace("\\", "\\\\").replace("\"", "\\\"");
   }
 
-  /** Extracts text content of a single jar entry, or null if absent/unreadable. */
-  private static String extractEntryText(Path jar, String entryName) {
+  // ---- jar utilities ----
+
+  private static String extractEntryText(Path jar, String entryName) throws IOException {
     try (JarFile jf = new JarFile(jar.toFile())) {
       JarEntry entry = jf.getJarEntry(entryName);
       if (entry == null) {
@@ -171,29 +180,23 @@ public final class EnrichExtensionYaml {
       try (InputStream is = jf.getInputStream(entry)) {
         return new String(is.readAllBytes(), StandardCharsets.UTF_8);
       }
-    } catch (IOException e) {
-      return null;
     }
   }
 
-  /** Checks whether a jar contains a given entry path. */
   private static boolean hasEntry(Path jar, String entryName) {
     try (JarFile jf = new JarFile(jar.toFile())) {
       return jf.getJarEntry(entryName) != null;
-    } catch (IOException e) {
+    } catch (IOException ignored) {
       return false;
     }
   }
 
   /**
-   * Extracts "groupId:artifactId" from pom.properties under META-INF/maven/ in the jar, or null if
-   * none.
-   *
-   * <p>Shaded jars can carry several pom.properties (their own plus relocated dependencies'), and
-   * jar entry order is arbitrary — so prefer the entry whose artifactId matches the jar's file name
-   * (Maven convention: {@code artifactId-version.jar}) over whichever happens to come first.
+   * Extracts "groupId:artifactId" from pom.properties in the jar. Prefers the entry whose
+   * artifactId matches the jar filename.
    */
-  private static String extractPomCoordinates(Path jar) {
+  @SuppressWarnings("PMD.EmptyCatchBlock") // best-effort: unreadable jar → skip
+  static String extractPomCoordinates(Path jar) {
     String fileName = jar.getFileName().toString();
     String fallback = null;
     try (JarFile jf = new JarFile(jar.toFile())) {
@@ -219,8 +222,8 @@ public final class EnrichExtensionYaml {
           }
         }
       }
-    } catch (IOException e) {
-      // Fall through
+    } catch (IOException ignored) {
+      // best-effort: unreadable jar → return fallback or null
     }
     return fallback;
   }

--- a/quarkifier/src/test/java/com/clementguillot/quarkifier/EnrichExtensionCommandTest.java
+++ b/quarkifier/src/test/java/com/clementguillot/quarkifier/EnrichExtensionCommandTest.java
@@ -1,0 +1,139 @@
+package com.clementguillot.quarkifier;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Integration tests for {@link EnrichExtensionCommand} via picocli. */
+class EnrichExtensionCommandTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void execute_validArgs_producesEnrichedYaml() throws IOException {
+    Path runtimeJar = createRuntimeJar("name: \"cli-ext\"\nmetadata:\n");
+    Path depJar = createExtensionJar("io.quarkus", "quarkus-arc");
+    Path cpFile = tempDir.resolve("cp.txt");
+    Files.writeString(cpFile, depJar.toString());
+    Path output = tempDir.resolve("output.yaml");
+
+    int exitCode =
+        QuarkifierCommand.createCommandLine()
+            .execute(
+                "enrich-extension",
+                runtimeJar.toString(),
+                output.toString(),
+                "3.33.2",
+                cpFile.toString(),
+                "cli-ext");
+
+    assertEquals(0, exitCode);
+    String result = Files.readString(output);
+    assertTrue(result.contains("built-with-quarkus-core: \"3.33.2\""));
+    assertTrue(result.contains("    - \"io.quarkus:quarkus-arc\""));
+  }
+
+  @Test
+  void execute_missingArgs_exitCodeTwo() {
+    int exitCode = QuarkifierCommand.createCommandLine().execute("enrich-extension");
+
+    assertEquals(2, exitCode);
+  }
+
+  @Test
+  void execute_help_exitCodeZero() {
+    int exitCode = QuarkifierCommand.createCommandLine().execute("enrich-extension", "--help");
+
+    assertEquals(0, exitCode);
+  }
+
+  @Test
+  void execute_missingRuntimeJar_exitCodeOne() throws IOException {
+    Path cpFile = tempDir.resolve("cp.txt");
+    Files.writeString(cpFile, "");
+    Path output = tempDir.resolve("output.yaml");
+
+    int exitCode =
+        QuarkifierCommand.createCommandLine()
+            .execute(
+                "enrich-extension",
+                "/nonexistent/runtime.jar",
+                output.toString(),
+                "3.33.2",
+                cpFile.toString(),
+                "broken");
+
+    assertEquals(1, exitCode);
+  }
+
+  @Test
+  void execute_noExtensionYamlInJar_producesDefaultOutput() throws IOException {
+    // Jar without META-INF/quarkus-extension.yaml
+    Path emptyJar = tempDir.resolve("empty-runtime.jar");
+    try (var jos = new JarOutputStream(new FileOutputStream(emptyJar.toFile()))) {
+      jos.putNextEntry(new JarEntry("com/example/Foo.class"));
+      jos.closeEntry();
+    }
+    Path cpFile = tempDir.resolve("cp.txt");
+    Files.writeString(cpFile, "");
+    Path output = tempDir.resolve("output.yaml");
+
+    int exitCode =
+        QuarkifierCommand.createCommandLine()
+            .execute(
+                "enrich-extension",
+                emptyJar.toString(),
+                output.toString(),
+                "3.33.2",
+                cpFile.toString(),
+                "fallback-name");
+
+    assertEquals(0, exitCode);
+    String result = Files.readString(output);
+    assertTrue(result.contains("name: \"fallback-name\""));
+    assertTrue(result.contains("built-with-quarkus-core: \"3.33.2\""));
+  }
+
+  // ---- helpers ----
+
+  private Path createRuntimeJar(String yamlContent) throws IOException {
+    Path jar = tempDir.resolve("runtime.jar");
+    try (var jos = new JarOutputStream(new FileOutputStream(jar.toFile()))) {
+      jos.putNextEntry(new JarEntry("META-INF/quarkus-extension.yaml"));
+      jos.write(yamlContent.getBytes(StandardCharsets.UTF_8));
+      jos.closeEntry();
+    }
+    return jar;
+  }
+
+  private Path createExtensionJar(String groupId, String artifactId) throws IOException {
+    Path jar = tempDir.resolve(artifactId + "-3.33.2.jar");
+    try (var jos = new JarOutputStream(new FileOutputStream(jar.toFile()))) {
+      // Extension marker
+      jos.putNextEntry(new JarEntry("META-INF/quarkus-extension.properties"));
+      jos.write(
+          ("deployment-artifact=" + groupId + ":" + artifactId + "-deployment:3.33.2\n")
+              .getBytes(StandardCharsets.UTF_8));
+      jos.closeEntry();
+      // pom.properties
+      String pomPath = "META-INF/maven/" + groupId + "/" + artifactId + "/pom.properties";
+      jos.putNextEntry(new JarEntry(pomPath));
+      Properties props = new Properties();
+      props.setProperty("groupId", groupId);
+      props.setProperty("artifactId", artifactId);
+      props.setProperty("version", "3.33.2");
+      props.store(jos, null);
+      jos.closeEntry();
+    }
+    return jar;
+  }
+}

--- a/quarkifier/src/test/java/com/clementguillot/quarkifier/QuarkifierConfigTest.java
+++ b/quarkifier/src/test/java/com/clementguillot/quarkifier/QuarkifierConfigTest.java
@@ -465,6 +465,12 @@ class QuarkifierConfigTest {
   }
 
   @Test
+  void noSubcommand_printsUsageExitZero() {
+    int exitCode = QuarkifierCommand.createCommandLine().execute();
+    assertEquals(0, exitCode);
+  }
+
+  @Test
   void version_exitCodeIsZero() {
     int exitCode = QuarkifierCommand.createCommandLine().execute("--version");
     assertEquals(0, exitCode);
@@ -472,8 +478,8 @@ class QuarkifierConfigTest {
 
   @Test
   void usageError_exitCodeIsTwo() {
-    // No args at all → missing required --output-dir
-    int exitCode = QuarkifierCommand.createCommandLine().execute();
+    // augmentation without required --output-dir → exit 2
+    int exitCode = QuarkifierCommand.createCommandLine().execute("augmentation");
     assertEquals(2, exitCode);
   }
 
@@ -483,7 +489,9 @@ class QuarkifierConfigTest {
     var errorOutput = new StringWriter();
     commandLine.setErr(new PrintWriter(errorOutput, true));
 
-    int exitCode = commandLine.execute("--deployment-classpath", "d.jar", "--output-dir", "/out");
+    int exitCode =
+        commandLine.execute(
+            "augmentation", "--deployment-classpath", "d.jar", "--output-dir", "/out");
 
     assertEquals(2, exitCode);
     assertTrue(errorOutput.toString().contains("--application-classpath"));

--- a/quarkifier/src/test/java/com/clementguillot/quarkifier/extension/ExtensionYamlEnricherTest.java
+++ b/quarkifier/src/test/java/com/clementguillot/quarkifier/extension/ExtensionYamlEnricherTest.java
@@ -1,0 +1,278 @@
+package com.clementguillot.quarkifier.extension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Unit tests for {@link ExtensionYamlEnricher}. */
+class ExtensionYamlEnricherTest {
+
+  @TempDir Path tempDir;
+
+  // ---- enrichMetadata ----
+
+  @Test
+  void enrichMetadata_nullInput_generatesNameAndMetadata() throws IOException {
+    String result = ExtensionYamlEnricher.enrichMetadata(null, "my-ext", "3.33.2", List.of());
+
+    assertTrue(result.contains("name: \"my-ext\""));
+    assertTrue(result.contains("built-with-quarkus-core: \"3.33.2\""));
+    assertTrue(result.contains("extension-dependencies:"));
+  }
+
+  @Test
+  void enrichMetadata_blankInput_generatesNameAndMetadata() throws IOException {
+    String result = ExtensionYamlEnricher.enrichMetadata("  ", "my-ext", "3.33.2", List.of());
+
+    assertTrue(result.contains("name: \"my-ext\""));
+    assertTrue(result.contains("built-with-quarkus-core: \"3.33.2\""));
+  }
+
+  @Test
+  void enrichMetadata_existingYaml_appendsToMetadata() throws IOException {
+    String input =
+        "name: \"hello\"\ndescription: \"A greeting extension\"\nmetadata:\n  status: stable\n";
+    String result =
+        ExtensionYamlEnricher.enrichMetadata(
+            input, "hello", "3.27.4", List.of("io.quarkus:quarkus-arc"));
+
+    assertTrue(result.contains("name: \"hello\""));
+    assertTrue(result.contains("status: stable"));
+    assertTrue(result.contains("built-with-quarkus-core: \"3.27.4\""));
+    assertTrue(result.contains("    - \"io.quarkus:quarkus-arc\""));
+  }
+
+  @Test
+  void enrichMetadata_noMetadataBlock_addsOne() throws IOException {
+    String input = "name: \"no-meta\"\ndescription: \"No metadata block\"\n";
+    String result = ExtensionYamlEnricher.enrichMetadata(input, "no-meta", "3.33.2", List.of());
+
+    assertTrue(result.contains("metadata:"));
+    assertTrue(result.contains("built-with-quarkus-core: \"3.33.2\""));
+  }
+
+  @Test
+  void enrichMetadata_replacesExistingGeneratedFields() throws IOException {
+    String input =
+        "name: \"re-enrich\"\n"
+            + "metadata:\n"
+            + "  built-with-quarkus-core: \"3.27.0\"\n"
+            + "  extension-dependencies:\n"
+            + "    - \"old:dep\"\n"
+            + "  status: preview\n";
+    String result =
+        ExtensionYamlEnricher.enrichMetadata(input, "re-enrich", "3.33.2", List.of("new:dep"));
+
+    // Old values replaced
+    assertFalse(result.contains("3.27.0"));
+    assertFalse(result.contains("old:dep"));
+    // New values present
+    assertTrue(result.contains("built-with-quarkus-core: \"3.33.2\""));
+    assertTrue(result.contains("    - \"new:dep\""));
+    // Non-generated fields preserved
+    assertTrue(result.contains("status: preview"));
+  }
+
+  @Test
+  void enrichMetadata_removesEntireGeneratedDependencyBlockWithCommentsAndAlternateIndentation()
+      throws IOException {
+    String input =
+        "name: \"re-enrich\"\n"
+            + "metadata:\n"
+            + "  extension-dependencies:\n"
+            + "    # generated dependency\n"
+            + "      - \"old:deeply-indented\"\n"
+            + "  - \"old:indentless\"\n"
+            + "  status: preview\n";
+
+    String result =
+        ExtensionYamlEnricher.enrichMetadata(input, "re-enrich", "3.33.2", List.of("new:dep"));
+
+    assertFalse(result.contains("generated dependency"));
+    assertFalse(result.contains("old:deeply-indented"));
+    assertFalse(result.contains("old:indentless"));
+    assertTrue(result.contains("  status: preview"));
+    assertTrue(result.contains("    - \"new:dep\""));
+  }
+
+  @Test
+  void enrichMetadata_multipleDeps_allPresent() throws IOException {
+    String result =
+        ExtensionYamlEnricher.enrichMetadata(
+            null, "multi", "3.33.2", List.of("b:b-lib", "a:a-lib", "c:c-lib"));
+
+    assertTrue(result.contains("    - \"a:a-lib\""));
+    assertTrue(result.contains("    - \"b:b-lib\""));
+    assertTrue(result.contains("    - \"c:c-lib\""));
+  }
+
+  @Test
+  void enrichMetadata_specialCharsInVersion_areEscaped() throws IOException {
+    String result = ExtensionYamlEnricher.enrichMetadata(null, "esc\"test", "3.33\\2", List.of());
+
+    assertTrue(result.contains("esc\\\"test"));
+    assertTrue(result.contains("3.33\\\\2"));
+  }
+
+  // ---- discoverExtensionDependencies ----
+
+  @Test
+  void discoverExtensionDependencies_emptyFile_returnsEmpty() throws IOException {
+    Path cpFile = tempDir.resolve("empty_cp.txt");
+    Files.writeString(cpFile, "");
+
+    Set<String> deps = ExtensionYamlEnricher.discoverExtensionDependencies(cpFile);
+
+    assertTrue(deps.isEmpty());
+  }
+
+  @Test
+  void discoverExtensionDependencies_nonExtensionJar_skipped(@TempDir Path jarDir)
+      throws IOException {
+    Path jar = createJarWithPom(jarDir, "plain-lib-1.0.jar", "org.example", "plain-lib", false);
+    Path cpFile = tempDir.resolve("cp.txt");
+    Files.writeString(cpFile, jar.toString());
+
+    Set<String> deps = ExtensionYamlEnricher.discoverExtensionDependencies(cpFile);
+
+    assertTrue(deps.isEmpty());
+  }
+
+  @Test
+  void discoverExtensionDependencies_extensionJar_discovered(@TempDir Path jarDir)
+      throws IOException {
+    Path jar =
+        createJarWithPom(jarDir, "quarkus-rest-3.33.2.jar", "io.quarkus", "quarkus-rest", true);
+    Path cpFile = tempDir.resolve("cp.txt");
+    Files.writeString(cpFile, jar.toString());
+
+    Set<String> deps = ExtensionYamlEnricher.discoverExtensionDependencies(cpFile);
+
+    assertEquals(Set.of("io.quarkus:quarkus-rest"), deps);
+  }
+
+  @Test
+  void discoverExtensionDependencies_nonexistentJar_skipped() throws IOException {
+    Path cpFile = tempDir.resolve("cp.txt");
+    Files.writeString(cpFile, "/nonexistent/path.jar");
+
+    Set<String> deps = ExtensionYamlEnricher.discoverExtensionDependencies(cpFile);
+
+    assertTrue(deps.isEmpty());
+  }
+
+  @Test
+  void discoverExtensionDependencies_blankLines_ignored(@TempDir Path jarDir) throws IOException {
+    Path jar =
+        createJarWithPom(jarDir, "quarkus-arc-3.33.2.jar", "io.quarkus", "quarkus-arc", true);
+    Path cpFile = tempDir.resolve("cp.txt");
+    Files.writeString(cpFile, "\n  \n" + jar + "\n\n");
+
+    Set<String> deps = ExtensionYamlEnricher.discoverExtensionDependencies(cpFile);
+
+    assertEquals(Set.of("io.quarkus:quarkus-arc"), deps);
+  }
+
+  // ---- extractPomCoordinates ----
+
+  @Test
+  void extractPomCoordinates_matchingFilename(@TempDir Path jarDir) throws IOException {
+    Path jar = createJarWithPom(jarDir, "my-lib-2.0.jar", "com.example", "my-lib", false);
+
+    assertEquals("com.example:my-lib", ExtensionYamlEnricher.extractPomCoordinates(jar));
+  }
+
+  @Test
+  void extractPomCoordinates_noPomProperties(@TempDir Path jarDir) throws IOException {
+    Path jar = jarDir.resolve("empty.jar");
+    try (var jos = new JarOutputStream(new FileOutputStream(jar.toFile()))) {
+      jos.putNextEntry(new JarEntry("com/example/Foo.class"));
+      jos.closeEntry();
+    }
+
+    assertNull(ExtensionYamlEnricher.extractPomCoordinates(jar));
+  }
+
+  // ---- enrich (end-to-end) ----
+
+  @Test
+  void enrich_endToEnd(@TempDir Path jarDir) throws IOException {
+    Path runtimeJar = createRuntimeJar(jarDir, "name: \"test-ext\"\nmetadata:\n  status: beta\n");
+    Path depJar =
+        createJarWithPom(jarDir, "quarkus-core-3.33.2.jar", "io.quarkus", "quarkus-core", true);
+    Path cpFile = tempDir.resolve("cp.txt");
+    Files.writeString(cpFile, depJar.toString());
+    Path output = tempDir.resolve("enriched.yaml");
+
+    ExtensionYamlEnricher.enrich(runtimeJar, output, "3.33.2", cpFile, "test-ext");
+
+    String result = Files.readString(output);
+    assertTrue(result.contains("name: \"test-ext\""));
+    assertTrue(result.contains("status: beta"));
+    assertTrue(result.contains("built-with-quarkus-core: \"3.33.2\""));
+    assertTrue(result.contains("    - \"io.quarkus:quarkus-core\""));
+  }
+
+  @Test
+  void enrich_missingRuntimeJar_throwsIOException() {
+    Path cpFile = tempDir.resolve("cp.txt");
+    assertDoesNotThrow(() -> Files.writeString(cpFile, ""));
+    Path output = tempDir.resolve("out.yaml");
+
+    assertThrows(
+        IOException.class,
+        () ->
+            ExtensionYamlEnricher.enrich(
+                Path.of("/nonexistent.jar"), output, "3.33.2", cpFile, "x"));
+  }
+
+  // ---- helpers ----
+
+  private Path createJarWithPom(
+      Path dir, String fileName, String groupId, String artifactId, boolean isExtension)
+      throws IOException {
+    Path jar = dir.resolve(fileName);
+    try (var jos = new JarOutputStream(new FileOutputStream(jar.toFile()))) {
+      // pom.properties
+      String pomPath = "META-INF/maven/" + groupId + "/" + artifactId + "/pom.properties";
+      jos.putNextEntry(new JarEntry(pomPath));
+      Properties props = new Properties();
+      props.setProperty("groupId", groupId);
+      props.setProperty("artifactId", artifactId);
+      props.setProperty("version", "1.0");
+      props.store(jos, null);
+      jos.closeEntry();
+
+      // Extension marker
+      if (isExtension) {
+        jos.putNextEntry(new JarEntry("META-INF/quarkus-extension.properties"));
+        jos.write(
+            ("deployment-artifact=" + groupId + ":" + artifactId + "-deployment:1.0\n")
+                .getBytes(StandardCharsets.UTF_8));
+        jos.closeEntry();
+      }
+    }
+    return jar;
+  }
+
+  private Path createRuntimeJar(Path dir, String yamlContent) throws IOException {
+    Path jar = dir.resolve("runtime.jar");
+    try (var jos = new JarOutputStream(new FileOutputStream(jar.toFile()))) {
+      jos.putNextEntry(new JarEntry("META-INF/quarkus-extension.yaml"));
+      jos.write(yamlContent.getBytes(StandardCharsets.UTF_8));
+      jos.closeEntry();
+    }
+    return jar;
+  }
+}

--- a/quarkus/extensions.bzl
+++ b/quarkus/extensions.bzl
@@ -733,6 +733,7 @@ def quarkus_extension_runtime(name, group_id, version, runtime_target, deploymen
         artifact_id = artifact_id,
         version = version,
         quarkus_version = _QUARKUS_VERSION,
+        quarkifier_tool = _QUARKIFIER_TOOL,
     )
 """
 

--- a/quarkus/private/BUILD.bazel
+++ b/quarkus/private/BUILD.bazel
@@ -1,7 +1,5 @@
 # Private implementation details for rules_quarkus.
 
-load("@rules_java//java:java_binary.bzl", "java_binary")
-
 exports_files([
     "launcher.sh.tpl",
     "dev_launcher.sh.tpl",
@@ -12,10 +10,3 @@ exports_files([
     "classpath_utils.bzl",
     "versions.bzl",
 ])
-
-java_binary(
-    name = "enrich_extension_yaml",
-    srcs = ["EnrichExtensionYaml.java"],
-    main_class = "com.clementguillot.rules_quarkus.EnrichExtensionYaml",
-    visibility = ["//quarkus:__subpackages__"],
-)

--- a/quarkus/private/augmentation.bzl
+++ b/quarkus/private/augmentation.bzl
@@ -73,6 +73,7 @@ def run_augmentation(ctx, output_dir, runtime_classpath, deployment_classpath, m
     jar_args.add("-Djava.util.logging.manager=org.jboss.logmanager.LogManager")
     jar_args.add("-jar")
     jar_args.add(tool_jar)
+    jar_args.add("augmentation")
 
     if mode == "native":
         mnemonic = "QuarkusNativeAugmentation"

--- a/quarkus/private/dev_launcher.sh.tpl
+++ b/quarkus/private/dev_launcher.sh.tpl
@@ -147,6 +147,7 @@ _JAVA_ARGFILE=$(mktemp "${OUTPUT_DIR}/quarkus_dev_args_XXXXXX")
   echo "-Djava.util.logging.manager=org.jboss.logmanager.LogManager"
   _q "-jar"
   _q "$TOOL_JAR"
+  echo "augmentation"
   echo "--application-classpath-file"
   _q "$ABS_APP_CP_FILE"
   echo "--deployment-classpath-file"

--- a/quarkus/private/quarkus_extension_impl.bzl
+++ b/quarkus/private/quarkus_extension_impl.bzl
@@ -80,17 +80,24 @@ def _enrich_extension_yaml(ctx, runtime_jar):
     classpath_args.add_all(compile_classpath)
     ctx.actions.write(output = classpath_file, content = classpath_args)
 
+    tool_jar = ctx.file.quarkifier_tool
+    java_runtime = ctx.attr._java_runtime[java_common.JavaRuntimeInfo]
+
+    args = ctx.actions.args()
+    args.add("-jar")
+    args.add(tool_jar)
+    args.add("enrich-extension")
+    args.add(runtime_jar)
+    args.add(enriched_yaml)
+    args.add(ctx.attr.quarkus_version)
+    args.add(classpath_file)
+    args.add(ctx.label.name)
+
     ctx.actions.run(
-        executable = ctx.executable._enrich_yaml,
-        inputs = depset([runtime_jar, classpath_file], transitive = [compile_classpath]),
+        executable = java_runtime.java_executable_exec_path,
+        inputs = depset([runtime_jar, classpath_file, tool_jar], transitive = [compile_classpath, java_runtime.files]),
         outputs = [enriched_yaml],
-        arguments = [
-            runtime_jar.path,
-            enriched_yaml.path,
-            ctx.attr.quarkus_version,
-            classpath_file.path,
-            ctx.label.name,
-        ],
+        arguments = [args],
         mnemonic = "QuarkusExtYaml",
         progress_message = "Enriching quarkus-extension.yaml for %{label}",
     )
@@ -271,10 +278,14 @@ quarkus_extension_runtime_rule = rule(
             executable = True,
             cfg = "exec",
         ),
-        "_enrich_yaml": attr.label(
-            default = Label("//quarkus/private:enrich_extension_yaml"),
-            executable = True,
+        "quarkifier_tool": attr.label(
+            allow_single_file = [".jar"],
+            doc = "Quarkifier deploy jar for extension enrichment (set by macro).",
+        ),
+        "_java_runtime": attr.label(
+            default = "@bazel_tools//tools/jdk:current_java_runtime",
             cfg = "exec",
+            providers = [java_common.JavaRuntimeInfo],
         ),
     },
     provides = [JavaInfo, QuarkusExtensionInfo],

--- a/quarkus/private/test_launcher.sh.tpl
+++ b/quarkus/private/test_launcher.sh.tpl
@@ -53,6 +53,7 @@ trap "rm -rf $MODEL_DIR" EXIT
 "$JAVA" \
   -Djava.util.logging.manager=org.jboss.logmanager.LogManager \
   -jar "$TOOL_JAR" \
+  augmentation \
   --application-classpath-file "$APP_CP_FILE" \
   --deployment-classpath-file "$COMBINED_DEPLOY_CP_FILE" \
   --output-dir "$MODEL_DIR" \


### PR DESCRIPTION
- Closes: #136 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `augmentation` subcommand for build-time augmentation (classpath resolution, output/mode selection, Quarkus version checking).
  * Added `enrich-extension` subcommand to enrich `quarkus-extension.yaml` with core version and discovered extension dependencies.
* **Build & Development**
  * Updated CLI delegation so parsing and dev/test launch flows route through the new subcommands; launcher now sets the JUL logging manager.
  * Updated Bazel packaging/runtime wiring for the augmentation/enrichment tool.
* **Bug Fixes**
  * Improved YAML enrichment/normalization, including correct metadata handling and generated-field replacement.
* **Documentation**
  * Refreshed CLI/dev-mode docs and exit-code meanings for the new flow.
* **Tests**
  * Updated and added integration/unit coverage for subcommands, exit codes, and YAML enrichment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->